### PR TITLE
fix: Add setuptools to requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -12,3 +12,4 @@ CTkListbox==0.9
 CTkMessagebox==2.5
 packaging==23.1
 pyqt6==6.6.1
+setuptools==75.6.0


### PR DESCRIPTION
## Description
This pull request fixes an installation issue that occurs on Windows when running the `install.bat` script. Without the setuptools package, the following error is encountered:

`ModuleNotFoundError: No module named 'distutils'`

![image](https://github.com/user-attachments/assets/fb291238-369c-473f-8a34-41fefee3a942)

## Changes Made
- Added setuptools==75.6.0 to requirements.txt to resolve the missing distutils module.