### PR TITLE
hotfix: scope status-ping Sentry to alert_delivery

### DIFF
--- a/web/__tests__/api/cron/status-ping.test.ts
+++ b/web/__tests__/api/cron/status-ping.test.ts
@@ -207,11 +207,31 @@ describe('GET /api/cron/status-ping', () => {
     expect(res.status).toBe(200);
     expect(body.updates).toHaveLength(1);
     expect(mockSetInstatusComponentStatus).toHaveBeenCalledWith('api', 'DEGRADEDPERFORMANCE');
+    // Sentry is scoped to alert_delivery — an api degrade still publishes to Instatus
+    // but does NOT page Sentry (avoids noise from the pre-existing api probe failures).
+    expect(mockCaptureMessage).not.toHaveBeenCalled();
+  });
+
+  it('raises Sentry for an alert_delivery degrade (scoped to that component)', async () => {
+    mockStatusGet.mockResolvedValueOnce(querySnapshot([
+      pingDoc('2', [health('alert_delivery', false)]),
+      pingDoc('1', [health('alert_delivery', true)]),
+    ]));
+    mockRunStatusHealthChecks.mockResolvedValueOnce([health('alert_delivery', false)]);
+    mockSetInstatusComponentStatus.mockResolvedValueOnce({
+      component: 'alert_delivery',
+      status: 'DEGRADEDPERFORMANCE',
+      ok: true,
+    });
+
+    const res = await GET(request('cron-secret'));
+
+    expect(res.status).toBe(200);
     expect(mockCaptureMessage).toHaveBeenCalledWith(
-      'status.api_degraded',
+      'status.alert_delivery_degraded',
       expect.objectContaining({
         level: 'error',
-        tags: expect.objectContaining({ status_component: 'api' }),
+        tags: expect.objectContaining({ status_component: 'alert_delivery' }),
       }),
     );
   });

--- a/web/app/api/cron/status-ping/route.ts
+++ b/web/app/api/cron/status-ping/route.ts
@@ -15,6 +15,12 @@ import {
 import { getAdminDb } from '@/lib/firebase-admin';
 import * as Sentry from '@sentry/nextjs';
 
+// Components whose degrade transition pages Sentry. Scoped to alert_delivery for
+// now: the HTTP-probe components (dashboard/api/agent_registry) currently produce
+// server-side-probe false-negatives, so paging on them would be noise. Broaden
+// this set once those probes are fixed.
+const SENTRY_ALERTING_COMPONENTS = new Set<StatusComponent>(['alert_delivery']);
+
 interface StatusPingDoc {
   id: string;
   observedAtMs: number;
@@ -217,6 +223,10 @@ export async function GET(request: NextRequest) {
         `[status-ping] component degraded: ${update.component}`,
         detail?.error ?? '',
       );
+      // Sentry is scoped to alert_delivery (see SENTRY_ALERTING_COMPONENTS): the
+      // HTTP-probe components have pre-existing server-side-probe false-negatives,
+      // so paging on them would be noise. Broaden the set once those are fixed.
+      if (!SENTRY_ALERTING_COMPONENTS.has(update.component)) continue;
       // Only forward non-identifying detail. The error string already carries the
       // safe summary (counts, status codes); raw component metadata can include a
       // machine hostname (agent_registry.latest_machine_id), so it is NOT sent.


### PR DESCRIPTION
Scopes the status-ping degrade→Sentry capture to alert_delivery only.

The generic capture was firing false alarms for the dashboard/api/agent_registry
status components, which have pre-existing server-side-probe false-negatives (the
endpoints are healthy externally but the origin's own fetch fails). Instatus
publish + console.error stay generic. Tested: jest + lint + tsc green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)