### PR TITLE
fix(web): consistent auth-page header hierarchy (2fa + add)

### DIFF
--- a/web/app/add/page.tsx
+++ b/web/app/add/page.tsx
@@ -197,9 +197,9 @@ export default function AddMachinePage() {
       <div className="absolute inset-0 blueprint-grid opacity-15" />
       <Card className="relative z-10 w-full max-w-lg border-border bg-card">
         <CardHeader className="space-y-4 flex flex-col items-center">
-          <OwletteEyeIcon size={48} />
+          <OwletteEyeIcon size={80} />
           <div className="space-y-1 text-center">
-            <CardTitle className="text-xl font-bold text-foreground">add machine</CardTitle>
+            <CardTitle className="text-2xl font-bold text-foreground">add machine</CardTitle>
             <CardDescription className="text-muted-foreground">
               enter the pairing phrase shown on your machine
             </CardDescription>

--- a/web/app/setup-2fa/page.tsx
+++ b/web/app/setup-2fa/page.tsx
@@ -7,6 +7,7 @@ import { generateBackupCodes } from '@/lib/totp';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+import { OwletteEyeIcon } from '@/components/landing/OwletteEye';
 import { toast } from 'sonner';
 import { PasskeyManager } from '@/components/PasskeyManager';
 /* eslint-disable @next/next/no-img-element */
@@ -142,11 +143,14 @@ export default function Setup2FAPage() {
       <div className="absolute inset-0 dot-grid opacity-30" />
       <div className="absolute inset-0 blueprint-grid opacity-15" />
       <Card className="relative z-10 w-full max-w-2xl border-border bg-card">
-        <CardHeader>
-          <CardTitle>set up two-factor authentication</CardTitle>
-          <CardDescription>
-            secure your account with two-factor authentication (2FA)
-          </CardDescription>
+        <CardHeader className="space-y-4 flex flex-col items-center">
+          <OwletteEyeIcon size={80} />
+          <div className="space-y-1 text-center">
+            <CardTitle className="text-2xl font-bold text-foreground">set up two-factor authentication</CardTitle>
+            <CardDescription className="text-muted-foreground">
+              secure your account with two-factor authentication (2FA)
+            </CardDescription>
+          </div>
         </CardHeader>
         <CardContent>
           {step === 'setup' && (

--- a/web/app/verify-2fa/page.tsx
+++ b/web/app/verify-2fa/page.tsx
@@ -10,6 +10,7 @@ import { Input } from '@/components/ui/input';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 import { Checkbox } from '@/components/ui/checkbox';
 import { Label } from '@/components/ui/label';
+import { OwletteEyeIcon } from '@/components/landing/OwletteEye';
 import { toast } from 'sonner';
 import { trustDevice } from '@/lib/mfaSession';
 
@@ -168,13 +169,16 @@ function Verify2FAContent() {
       <div className="absolute inset-0 dot-grid opacity-30" />
       <div className="absolute inset-0 blueprint-grid opacity-15" />
       <Card className="relative z-10 w-full max-w-md border-border bg-card">
-        <CardHeader>
-          <CardTitle>two-factor authentication</CardTitle>
-          <CardDescription>
-            {useBackupCode
-              ? 'enter one of your backup codes'
-              : 'enter the code from your authenticator app'}
-          </CardDescription>
+        <CardHeader className="space-y-4 flex flex-col items-center">
+          <OwletteEyeIcon size={80} />
+          <div className="space-y-1 text-center">
+            <CardTitle className="text-2xl font-bold text-foreground">two-factor authentication</CardTitle>
+            <CardDescription className="text-muted-foreground">
+              {useBackupCode
+                ? 'enter one of your backup codes'
+                : 'enter the code from your authenticator app'}
+            </CardDescription>
+          </div>
         </CardHeader>
         <CardContent>
           <form onSubmit={handleVerify} className="space-y-6">


### PR DESCRIPTION
Cosmetic-only follow-up to 2.12.9. Aligns the header of `verify-2fa`, `setup-2fa`, and `add` with the rest of the logged-out auth-card family (centered 80px Owlette eye anchor + `text-2xl` bold title + muted description), matching login / forgot-password / register / reset-password.

- **Scope:** 3 page files, header markup/className only. No logic, API, firestore rules, or index changes — so **no `firebase deploy` needed**.
- `CardTitle` text + form markup unchanged → MFA e2e selectors (case-insensitive) still match.
- dev CI green on this commit (playwright e2e + no-token-logs).

Left out by design: `cli/authorize` (in-app page, uses PageHeader — intentionally not in this family) and `unsubscribe` (optional).