### PR TITLE
fix(web): harden signup against bot/spam abuse (tier 2)

### DIFF
--- a/web/__tests__/api/users-bootstrap.test.ts
+++ b/web/__tests__/api/users-bootstrap.test.ts
@@ -1,0 +1,118 @@
+/** @jest-environment node */
+
+/**
+ * Route-level tests for POST /api/users/bootstrap — the two signup-abuse
+ * controls added in the signup-abuse-tier2 PR.
+ *
+ * The pure helpers (isDisposableEmailDomain, sanitizeDisplayName) are unit-
+ * tested elsewhere; these tests pin the ROUTE wiring that those unit tests
+ * can't see:
+ *   - a disposable-domain email is rejected with 400 BEFORE any DB write
+ *     (bootstrapUser is never called), and
+ *   - the per-IP signup rate limit short-circuits with 429 before the handler
+ *     runs.
+ * A regression that dropped the withRateLimit wrap, or moved the disposable
+ * check after the bootstrap write, would pass every existing test but fail here.
+ */
+
+import { createMockRequest, parseResponse } from './helpers/utils';
+
+jest.mock('@sentry/nextjs', () => ({
+  captureException: jest.fn(),
+  captureMessage: jest.fn(),
+}));
+
+const mockRequireSessionOrIdToken = jest.fn();
+jest.mock('@/lib/apiAuth.server', () => {
+  const actual = jest.requireActual('@/lib/apiAuth.server');
+  return {
+    ...actual,
+    requireSessionOrIdToken: (...a: unknown[]) => mockRequireSessionOrIdToken(...a),
+  };
+});
+
+const mockBootstrapUser = jest.fn();
+jest.mock('@/lib/actions/bootstrapUser.server', () => ({
+  bootstrapUser: (...a: unknown[]) => mockBootstrapUser(...a),
+}));
+
+// Idempotency wrapper: just run the inner handler (no Firestore cache in tests).
+jest.mock('@/lib/idempotency', () => ({
+  withIdempotency: (
+    _req: unknown,
+    _ctx: unknown,
+    _raw: unknown,
+    handler: () => unknown,
+  ) => handler(),
+}));
+
+// Control the rate-limit verdict directly (real Upstash/in-memory limiter is
+// bypassed). Keep getClientIp / getRateLimitHeaders / limiter consts real.
+const mockCheckRateLimit = jest.fn();
+jest.mock('@/lib/rateLimit', () => {
+  const actual = jest.requireActual('@/lib/rateLimit');
+  return { ...actual, checkRateLimit: (...a: unknown[]) => mockCheckRateLimit(...a) };
+});
+
+import { POST } from '@/app/api/users/bootstrap/route';
+
+function bootstrapReq(body: Record<string, unknown>) {
+  return createMockRequest('/api/users/bootstrap', { method: 'POST', body });
+}
+
+describe('POST /api/users/bootstrap — abuse controls', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockRequireSessionOrIdToken.mockResolvedValue('uid-test');
+    mockBootstrapUser.mockResolvedValue({
+      kind: 'created',
+      uid: 'uid-test',
+      email: 'real@gmail.com',
+      displayName: '',
+      timezone: 'UTC',
+      createdAt: 1,
+    });
+    mockCheckRateLimit.mockResolvedValue({
+      success: true,
+      limit: 10,
+      remaining: 9,
+      reset: 1_000_000,
+    });
+  });
+
+  it('rejects a disposable-domain email with 400 and never writes the user doc', async () => {
+    const res = await POST(bootstrapReq({ email: 'bot@mailinator.com' }));
+    const { status, body } = await parseResponse(res);
+    expect(status).toBe(400);
+    expect(JSON.stringify(body)).toMatch(/disposable/i);
+    expect(mockBootstrapUser).not.toHaveBeenCalled();
+  });
+
+  it('lets a normal email through to bootstrap', async () => {
+    const res = await POST(bootstrapReq({ email: 'real@gmail.com', displayName: 'Real Person' }));
+    const { status } = await parseResponse(res);
+    expect(status).toBe(200);
+    expect(mockBootstrapUser).toHaveBeenCalledTimes(1);
+  });
+
+  it('returns 429 and never writes when the signup rate limit is exceeded', async () => {
+    mockCheckRateLimit.mockResolvedValue({
+      success: false,
+      retryAfter: 30,
+      limit: 10,
+      remaining: 0,
+      reset: 1_000_000,
+    });
+    const res = await POST(bootstrapReq({ email: 'real@gmail.com' }));
+    const { status } = await parseResponse(res);
+    expect(status).toBe(429);
+    expect(mockBootstrapUser).not.toHaveBeenCalled();
+  });
+
+  it('rejects a malformed email with 400 before the disposable check (validation order)', async () => {
+    const res = await POST(bootstrapReq({ email: 'not-an-email' }));
+    const { status } = await parseResponse(res);
+    expect(status).toBe(400);
+    expect(mockBootstrapUser).not.toHaveBeenCalled();
+  });
+});

--- a/web/__tests__/lib/actions/UserRole.assignSite.removeSite.deleteUser.bootstrapUser.createSite.updateSite.deleteSite.test.ts
+++ b/web/__tests__/lib/actions/UserRole.assignSite.removeSite.deleteUser.bootstrapUser.createSite.updateSite.deleteSite.test.ts
@@ -331,6 +331,25 @@ describe('bootstrapUser', () => {
 
     expect(result).toEqual({ kind: 'already_exists', createdAt: 456 });
   });
+
+  it('sanitises a spam display name before persisting', async () => {
+    const db = new FakeDb();
+    const now = new Date('2026-01-02T03:04:05.000Z');
+
+    const result = await bootstrapUser(ctx, {
+      uid: 'uid-spam',
+      email: 'salavat@example.com',
+      displayName: '15K lira bonus kapıda! https://bit.ly/trclicko 🔥 Go',
+      db: db.asFirestore(),
+      now: () => now,
+    });
+
+    expect(result.kind).toBe('created');
+    const stored = db.docs.get('users/uid-spam') as { displayName: string };
+    expect(stored.displayName).toBe('15K lira bonus kapıda! 🔥 Go');
+    expect(stored.displayName).not.toContain('bit.ly');
+    expect(stored.displayName).not.toMatch(/https?:/i);
+  });
 });
 
 describe('site CRUD actions', () => {

--- a/web/__tests__/lib/disposableEmailDomains.test.ts
+++ b/web/__tests__/lib/disposableEmailDomains.test.ts
@@ -1,0 +1,58 @@
+/**
+ * @jest-environment node
+ *
+ * tests for web/lib/disposableEmailDomains.ts (signup-abuse hardening).
+ */
+import {
+  DISPOSABLE_EMAIL_DOMAINS,
+  isDisposableEmailDomain,
+} from '@/lib/disposableEmailDomains';
+
+describe('isDisposableEmailDomain', () => {
+  it('flags a known disposable domain', () => {
+    expect(isDisposableEmailDomain('bot@mailinator.com')).toBe(true);
+    expect(isDisposableEmailDomain('x@guerrillamail.com')).toBe(true);
+    expect(isDisposableEmailDomain('y@bit.example')).toBe(false);
+  });
+
+  it('is case-insensitive on the domain', () => {
+    expect(isDisposableEmailDomain('Bot@MailInator.com')).toBe(true);
+  });
+
+  it('matches on the last @ (handles quoted local parts)', () => {
+    expect(isDisposableEmailDomain('weird@local@yopmail.com')).toBe(true);
+  });
+
+  it('does NOT flag mainstream providers — including the ya.ru spam vector', () => {
+    // The wave that motivated this used a *legitimate* Yandex address; a
+    // domain blocklist is defence-in-depth only and must never block real
+    // consumer providers.
+    for (const domain of [
+      'ya.ru',
+      'yandex.ru',
+      'gmail.com',
+      'outlook.com',
+      'proton.me',
+      'icloud.com',
+      'fastmail.com',
+    ]) {
+      expect(isDisposableEmailDomain(`user@${domain}`)).toBe(false);
+    }
+  });
+
+  it('returns false for malformed / non-string input', () => {
+    expect(isDisposableEmailDomain('no-at-sign')).toBe(false);
+    expect(isDisposableEmailDomain('trailing@')).toBe(false);
+    expect(isDisposableEmailDomain('')).toBe(false);
+    // @ts-expect-error — exercising the runtime guard
+    expect(isDisposableEmailDomain(undefined)).toBe(false);
+  });
+
+  it('keeps the blocklist lowercased and free of mainstream providers', () => {
+    for (const domain of DISPOSABLE_EMAIL_DOMAINS) {
+      expect(domain).toBe(domain.toLowerCase());
+    }
+    expect(DISPOSABLE_EMAIL_DOMAINS.has('gmail.com')).toBe(false);
+    expect(DISPOSABLE_EMAIL_DOMAINS.has('ya.ru')).toBe(false);
+  });
+});

--- a/web/__tests__/lib/sanitize.test.ts
+++ b/web/__tests__/lib/sanitize.test.ts
@@ -3,7 +3,11 @@
  *
  * tests for web/lib/sanitize.ts (roost wave 3.8).
  */
-import { isFilenameClean, sanitizeFilename } from '@/lib/sanitize';
+import {
+  isFilenameClean,
+  sanitizeDisplayName,
+  sanitizeFilename,
+} from '@/lib/sanitize';
 
 describe('sanitizeFilename', () => {
   describe('happy path', () => {
@@ -243,5 +247,74 @@ describe('isFilenameClean', () => {
 
   it('is false when sanitiser would reject the name', () => {
     expect(isFilenameClean('has/slash.toe')).toBe(false);
+  });
+});
+
+describe('sanitizeDisplayName', () => {
+  describe('happy path', () => {
+    it('passes a clean name through unchanged', () => {
+      expect(sanitizeDisplayName('John Doe')).toBe('John Doe');
+    });
+
+    it('preserves accented + CJK names', () => {
+      expect(sanitizeDisplayName('José 田中')).toBe('José 田中');
+    });
+
+    it('preserves dotted initials (no false-positive domain strip)', () => {
+      expect(sanitizeDisplayName('J.R.R. Tolkien')).toBe('J.R.R. Tolkien');
+      expect(sanitizeDisplayName('Ph.D Smith')).toBe('Ph.D Smith');
+    });
+
+    it('keeps a small number of emoji', () => {
+      expect(sanitizeDisplayName('Sarah ✨')).toBe('Sarah ✨');
+    });
+  });
+
+  describe('signup-spam payloads', () => {
+    it('strips a scheme URL from the billboard display name', () => {
+      const out = sanitizeDisplayName(
+        '15K lira bonus kapıda! https://bit.ly/trclicko 🔥 Go',
+      );
+      expect(out).toBe('15K lira bonus kapıda! 🔥 Go');
+      expect(out).not.toMatch(/https?:/i);
+      expect(out).not.toContain('bit.ly');
+    });
+
+    it('strips a bare shortener domain without a scheme', () => {
+      expect(sanitizeDisplayName('win now bit.ly/abc def')).toBe('win now def');
+    });
+
+    it('strips a www-prefixed host', () => {
+      expect(sanitizeDisplayName('hi www.spam.example bye')).toBe('hi bye');
+    });
+
+    it('caps an emoji wall to two', () => {
+      expect(sanitizeDisplayName('deal 🔥🔥🔥🔥🔥')).toBe('deal 🔥🔥');
+    });
+
+    it('strips RTL-override + zero-width spoof characters', () => {
+      expect(sanitizeDisplayName('admin‮redmin​')).toBe('adminredmin');
+    });
+
+    it('reduces a name that is only a link to empty', () => {
+      expect(sanitizeDisplayName('https://bit.ly/x')).toBe('');
+    });
+  });
+
+  describe('edge cases', () => {
+    it('returns empty string for non-string input', () => {
+      expect(sanitizeDisplayName(undefined)).toBe('');
+      expect(sanitizeDisplayName(null)).toBe('');
+      expect(sanitizeDisplayName(42)).toBe('');
+    });
+
+    it('caps length to 64 codepoints', () => {
+      const long = 'a'.repeat(200);
+      expect(Array.from(sanitizeDisplayName(long)).length).toBe(64);
+    });
+
+    it('collapses runs of whitespace', () => {
+      expect(sanitizeDisplayName('a    b\t\tc')).toBe('a b c');
+    });
   });
 });

--- a/web/app/api/users/bootstrap/route.ts
+++ b/web/app/api/users/bootstrap/route.ts
@@ -38,7 +38,9 @@ import {
   problemValidation,
 } from '@/lib/apiErrors';
 import { withIdempotency } from '@/lib/idempotency';
+import { withRateLimit } from '@/lib/withRateLimit';
 import { bootstrapUser } from '@/lib/actions/bootstrapUser.server';
+import { isDisposableEmailDomain } from '@/lib/disposableEmailDomains';
 import { readAndParseJsonBody } from '../../_shared';
 
 interface BootstrapBody {
@@ -50,7 +52,7 @@ interface BootstrapBody {
 const EMAIL_REGEX = /^[^@\s]+@[^@\s]+\.[^@\s]+$/;
 const MAX_DISPLAY_NAME = 200;
 
-export async function POST(request: NextRequest) {
+async function handleBootstrap(request: NextRequest): Promise<NextResponse> {
   try {
     let userId: string;
     try {
@@ -74,6 +76,12 @@ export async function POST(request: NextRequest) {
           return problemValidation(
             'email is required and must be a valid email address',
             { 'body.email': ['must be a valid email address'] },
+          );
+        }
+        if (isDisposableEmailDomain(body.email)) {
+          return problemValidation(
+            'email address uses a disallowed disposable domain',
+            { 'body.email': ['disposable email domains are not permitted'] },
           );
         }
         if (
@@ -133,3 +141,14 @@ export async function POST(request: NextRequest) {
     return problemFromError(err, 'users/bootstrap:POST');
   }
 }
+
+/**
+ * Per-IP signup rate limit (10/hr prod, 100/hr dev). This caps creation of
+ * the Firestore `users/{uid}` doc — the visible/admin-table surface — not
+ * the upstream Firebase Auth account itself (that belongs to App Check /
+ * blocking functions). Honors the `E2E_DISABLE_RATE_LIMIT` escape hatch.
+ */
+export const POST = withRateLimit(handleBootstrap, {
+  strategy: 'signup',
+  identifier: 'ip',
+});

--- a/web/lib/actions/bootstrapUser.server.ts
+++ b/web/lib/actions/bootstrapUser.server.ts
@@ -24,6 +24,7 @@ import type { Firestore } from 'firebase-admin/firestore';
 import { getAdminDb } from '@/lib/firebase-admin';
 import { emitMutation } from '@/lib/auditLogClient';
 import { isValidTimezone } from '@/lib/timeUtils';
+import { sanitizeDisplayName } from '@/lib/sanitize';
 
 export interface BootstrapUserInput {
   uid: string;
@@ -71,8 +72,10 @@ export async function bootstrapUser(
   const db = input.db ?? getAdminDb();
   const userRef = db.collection('users').doc(input.uid);
 
-  const displayName =
-    typeof input.displayName === 'string' ? input.displayName : '';
+  // Sanitise the display name at the single write chokepoint — strips link
+  // payloads / emoji-spam / invisible chars regardless of whether the caller
+  // came through the signup form or hit the API directly with a scraped key.
+  const displayName = sanitizeDisplayName(input.displayName);
   const timezone =
     typeof input.timezone === 'string' && isValidTimezone(input.timezone)
       ? input.timezone

--- a/web/lib/disposableEmailDomains.ts
+++ b/web/lib/disposableEmailDomains.ts
@@ -1,0 +1,77 @@
+/**
+ * disposableEmailDomains — curated blocklist of throwaway / temp-mail
+ * providers used to gate self-serve signup (see /api/users/bootstrap).
+ *
+ * Scope: KNOWN burner-mail providers only. We deliberately DON'T list
+ * mainstream consumer providers (gmail, outlook, yahoo, proton, icloud,
+ * gmx, fastmail, zoho, and yandex / `ya.ru`) — those are where real users
+ * live. The spam wave that motivated this used `ya.ru` (legitimate Yandex),
+ * which is exactly why a domain blocklist is only defence-in-depth, not the
+ * primary control: the display-name sanitiser + per-IP signup rate limit do
+ * the heavy lifting against that vector.
+ *
+ * Matching is EXACT domain (the part after the last `@`, lowercased). We
+ * avoid suffix matching on purpose — it would risk false positives against
+ * lookalike legitimate domains, and an inert orphaned Firebase Auth account
+ * (no Firestore doc → no access, invisible in the admin table) is the cost
+ * of a false rejection here, so we keep the list explicit and conservative.
+ */
+
+export const DISPOSABLE_EMAIL_DOMAINS: ReadonlySet<string> = new Set([
+  '10minutemail.com',
+  '10minutemail.net',
+  '20minutemail.com',
+  'temp-mail.org',
+  'tempmail.com',
+  'tempmailo.com',
+  'tempmail.plus',
+  'tempr.email',
+  'guerrillamail.com',
+  'guerrillamail.net',
+  'guerrillamail.org',
+  'sharklasers.com',
+  'grr.la',
+  'mailinator.com',
+  'mailinator.net',
+  'maildrop.cc',
+  'mailnesia.com',
+  'mailcatch.com',
+  'mailsac.com',
+  'getnada.com',
+  'nada.email',
+  'dispostable.com',
+  'trashmail.com',
+  'trashmail.de',
+  'yopmail.com',
+  'yopmail.net',
+  'yopmail.fr',
+  'throwawaymail.com',
+  'fakeinbox.com',
+  'spam4.me',
+  'spambox.us',
+  'mintemail.com',
+  'mohmal.com',
+  'emailondeck.com',
+  'moakt.com',
+  'burnermail.io',
+  '33mail.com',
+  'pokemail.net',
+  'mailpoof.com',
+  'vomoto.com',
+  'inboxbear.com',
+  'mvrht.net',
+]);
+
+/**
+ * True if `email`'s domain is a known disposable / throwaway provider.
+ * Returns false for malformed input (the caller validates format
+ * separately) so this never masks a missing format check.
+ */
+export function isDisposableEmailDomain(email: string): boolean {
+  if (typeof email !== 'string') return false;
+  const at = email.lastIndexOf('@');
+  if (at === -1) return false;
+  const domain = email.slice(at + 1).trim().toLowerCase();
+  if (!domain) return false;
+  return DISPOSABLE_EMAIL_DOMAINS.has(domain);
+}

--- a/web/lib/rateLimit.ts
+++ b/web/lib/rateLimit.ts
@@ -50,6 +50,23 @@ export const authRateLimit = redis
   : null;
 
 /**
+ * Self-serve signup limiter — guards POST /api/users/bootstrap, the write
+ * that creates a `users/{uid}` doc (i.e. a row in the admin user table).
+ * Account creation from a single IP is a rare event, so this is far tighter
+ * than the general auth limiter — it blunts a bot spraying signups without
+ * touching a human onboarding their team.
+ * Prod: 10/hr per IP. Dev: 100/hr to keep local iteration unblocked.
+ */
+export const signupRateLimit = redis
+  ? new Ratelimit({
+      redis,
+      limiter: Ratelimit.slidingWindow(isDevEnv ? 100 : 10, '1 h'),
+      prefix: 'signup',
+      analytics: true,
+    })
+  : null;
+
+/**
  * Rate limiter for token exchange / device code operations
  * Prod: 60/hr (supports bulk deployment of many machines from one IP)
  * Dev: 200/hr (allows rapid iteration during testing)

--- a/web/lib/sanitize.ts
+++ b/web/lib/sanitize.ts
@@ -153,3 +153,78 @@ export function isFilenameClean(input: string): boolean {
   const result = sanitizeFilename(input);
   return result.ok && !result.changed;
 }
+
+/* -------------------------------------------------------------------------- */
+/*  display-name sanitiser (signup-abuse hardening)                            */
+/* -------------------------------------------------------------------------- */
+
+/** Max grapheme-length we persist for a user display name. */
+const MAX_DISPLAY_NAME_LENGTH = 64;
+
+/** Max pictographic codepoints we keep — beyond this is emoji-spam. */
+const MAX_DISPLAY_NAME_EMOJI = 2;
+
+/**
+ * URL-shaped substrings. A display name is never a legitimate place for a
+ * link, but signup bots stuff them with ads like
+ * `15K lira bonus! https://bit.ly/xxxx 🔥` (the row that motivated this).
+ * We strip three shapes, replacing each with a space so neighbouring words
+ * don't merge:
+ *   1. explicit schemes (`http://`, `https://`, `ftp://`, …)
+ *   2. `www.`-prefixed hosts
+ *   3. bare `label.tld[/path]` tokens for a curated TLD set (covers
+ *      shorteners like `bit.ly`). The `(?:[a-z0-9-]+\.)+` prefix requires a
+ *      real `host.tld` shape, so initials like "J.R." or "Ph.D" survive.
+ */
+const URL_SCHEME_RE = /\b[a-z][a-z0-9+.-]*:\/\/\S+/gi;
+const WWW_RE = /\bwww\.\S+/gi;
+const BARE_DOMAIN_RE =
+  /\b(?:[a-z0-9-]+\.)+(?:com|net|org|io|ly|gl|gd|me|co|app|link|click|xyz|top|info|biz|ru|tr|de|uk|cn|site|online|store|live|vip|win|bet)\b\/?\S*/gi;
+
+/** All extended-pictographic (emoji) codepoints. */
+const PICTOGRAPHIC_RE = /\p{Extended_Pictographic}/gu;
+
+/**
+ * Normalise a user-supplied display name for safe storage and display.
+ *
+ * Unlike {@link sanitizeFilename} this NEVER rejects — an empty display name
+ * is legal (the bootstrap action already defaults it to `''`), so the worst
+ * case for a hostile input is that it cleans down to an empty string. React
+ * escapes text on render, so this is defence-in-depth: its real job is to
+ * strip the *actionable* payload (links) and the visual noise (emoji spam,
+ * invisible/RTL spoof characters) before the value is persisted and echoed
+ * back in admin tables, toasts, and `aria-label`s.
+ *
+ * Pipeline: NFC → strip invisible/control chars → strip URLs → cap emoji →
+ * collapse whitespace → trim → cap length.
+ */
+export function sanitizeDisplayName(input: unknown): string {
+  if (typeof input !== 'string') return '';
+
+  let value = input.normalize('NFC');
+  // Invisible / RTL-override chars are deleted (they're pure spoofs); control
+  // chars (tab, newline, CR, …) become a space so they separate words rather
+  // than silently joining them.
+  value = value.replace(INVISIBLE_RE, '').replace(CONTROL_CHARS_RE, ' ');
+  value = value
+    .replace(URL_SCHEME_RE, ' ')
+    .replace(WWW_RE, ' ')
+    .replace(BARE_DOMAIN_RE, ' ');
+
+  // Keep at most MAX_DISPLAY_NAME_EMOJI emoji; drop the rest. A name with a
+  // single flag/star is fine; a wall of 🔥🔥🔥 is decoration around spam.
+  let emojiSeen = 0;
+  value = value.replace(PICTOGRAPHIC_RE, (m) =>
+    ++emojiSeen > MAX_DISPLAY_NAME_EMOJI ? '' : m,
+  );
+
+  value = value.replace(/\s+/g, ' ').trim();
+
+  // Truncate by codepoint (not UTF-16 unit) so CJK/emoji aren't split.
+  const codepoints = Array.from(value);
+  if (codepoints.length > MAX_DISPLAY_NAME_LENGTH) {
+    value = codepoints.slice(0, MAX_DISPLAY_NAME_LENGTH).join('').trim();
+  }
+
+  return value;
+}

--- a/web/lib/withRateLimit.ts
+++ b/web/lib/withRateLimit.ts
@@ -22,6 +22,7 @@
 import type { NextRequest, NextResponse } from 'next/server';
 import {
   authRateLimit,
+  signupRateLimit,
   tokenExchangeRateLimit,
   tokenRefreshRateLimit,
   userRateLimit,
@@ -35,7 +36,7 @@ import {
 } from './rateLimit';
 import { problem, ProblemType } from './apiErrors';
 
-type RateLimitStrategy = 'auth' | 'tokenExchange' | 'tokenRefresh' | 'user' | 'agentAlert' | 'upload' | 'api';
+type RateLimitStrategy = 'auth' | 'signup' | 'tokenExchange' | 'tokenRefresh' | 'user' | 'agentAlert' | 'upload' | 'api';
 type IdentifierType = 'ip' | 'user';
 
 interface RateLimitOptions {
@@ -50,7 +51,12 @@ function reasonFor(strategy: RateLimitStrategy, identifier: IdentifierType): Rat
   if (strategy === 'user' || strategy === 'api') {
     return identifier === 'user' ? 'key-rate' : 'endpoint-rate';
   }
-  if (strategy === 'auth' || strategy === 'tokenExchange' || strategy === 'tokenRefresh') {
+  if (
+    strategy === 'auth' ||
+    strategy === 'signup' ||
+    strategy === 'tokenExchange' ||
+    strategy === 'tokenRefresh'
+  ) {
     return 'endpoint-rate';
   }
   if (strategy === 'upload' || strategy === 'agentAlert') {
@@ -101,6 +107,7 @@ export function withRateLimit<TArgs extends unknown[]>(
     // Select rate limiter based on strategy
     const ratelimiter =
       options.strategy === 'auth' ? authRateLimit :
+      options.strategy === 'signup' ? signupRateLimit :
       options.strategy === 'tokenExchange' ? tokenExchangeRateLimit :
       options.strategy === 'tokenRefresh' ? tokenRefreshRateLimit :
       options.strategy === 'user' ? userRateLimit :


### PR DESCRIPTION
## why

A spam bot self-registered with a Turkish gambling ad stuffed into its display name (`salavat@ya.ru` — *"15K lira bonus kapıda! https://bit.ly/trclicko 🔥 Go"*). Self-serve signup had **zero abuse controls**: no rate limit, no input sanitization, no disposable-email gating.

**Severity is contained, not critical.** Firestore rules already pin new accounts to `role=member` / `sites=[]` / mandatory 2FA, so a spam account has **no data access** and the display name renders as **escaped JSX** (the `bit.ly` link is inert text, not a clickable link or XSS). The real harms are admin user-list pollution, the display name as a *billboard*, and Firebase Auth quota — i.e. spam hygiene.

This is **Tier 2** of a layered plan (server-side gates that reuse existing infra). Tier 1 (Firebase App Check / Auth blocking functions, which cap the upstream Auth account itself) is tracked separately.

## what

Three server-side layers at the `/api/users/bootstrap` chokepoint (the write that creates the `users/{uid}` doc — i.e. the row in the admin table):

1. **Per-IP signup rate limit** — new `signupRateLimit` preset (10/hr prod, 100/hr dev) wired through `withRateLimit`, same pattern as `forgot-password`. Only fires on first-login bootstrap (the auth listener bootstraps **solely when the user doc is missing**), so returning users behind a NAT are unaffected. Honors the `E2E_DISABLE_RATE_LIMIT` escape hatch → no CI impact.
2. **`sanitizeDisplayName()`** — strips URLs (incl. bare `bit.ly/…`), caps emoji, removes invisible/RTL-override spoof chars, caps length. Applied in `bootstrapUser.server.ts` (single write chokepoint), so it covers **both** the signup form and direct Firebase-API signups. This is what actually neutralizes *this* attack's payload.
3. **`isDisposableEmailDomain()`** — curated temp-mail blocklist; rejects with a 400.

## honest caveats (please read)

- **`ya.ru` is legitimate Yandex**, deliberately *not* on the blocklist — so layer #3 would **not** have stopped this specific bot. Layers #2 (URL strip) + #1 (rate cap) are what defuse it; #3 is defense-in-depth for the common temp-mail vector.
- Rejecting at bootstrap leaves an **inert orphaned Firebase Auth account** (no Firestore doc → no access, invisible in the admin table). Capping account creation at the Auth layer is Tier 1.
- The `signupRateLimit` numbers are starting points — tune if a legit org onboards >10 brand-new accounts/hr from one IP.

## tests

- `sanitizeDisplayName` + `isDisposableEmailDomain` unit suites; spam-name case added to the bootstrap action test. **63 passing.**
- One test caught a real bug (tabs/newlines were *deleted*, silently joining words) — fixed to collapse control chars to a space for display names.
- Lint clean; `tsc` clean for all touched files.

> ⚠️ Full Playwright e2e not run locally (heavy). Recommend `/preflight` before merge; PR CI e2e will also gate.

## follow-ups (not in this PR)
- Tier 1: Firebase App Check (enforce) + Auth blocking functions.
- One-off cleanup of existing spam rows.
- Optional: Cloudflare Turnstile on the register form.

🤖 Generated with [Claude Code](https://claude.com/claude-code)