### PR TITLE
feat(web): readable site names in alert emails + a "manage alerts" link

### DIFF
--- a/web/__tests__/api/cron/health-check.test.ts
+++ b/web/__tests__/api/cron/health-check.test.ts
@@ -47,6 +47,7 @@ jest.mock('@/lib/firebase-admin', () => ({
 
 jest.mock('@/lib/adminUtils.server', () => ({
   getSiteAlertRecipients: (...args: unknown[]) => getSiteAlertRecipientsMock(...args),
+  getSiteLabel: async (siteId: string) => siteId,
 }));
 
 jest.mock('@/lib/resendClient.server', () => ({

--- a/web/app/api/alerts/trigger/route.ts
+++ b/web/app/api/alerts/trigger/route.ts
@@ -1,6 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { getAdminDb } from '@/lib/firebase-admin';
-import { getSiteAlertRecipients, getMachineTimezone } from '@/lib/adminUtils.server';
+import { getSiteAlertRecipients, getMachineTimezone, getSiteLabel } from '@/lib/adminUtils.server';
 import { generateUnsubscribeToken } from '@/app/api/unsubscribe/route';
 import { getResend, FROM_EMAIL, ENV_LABEL } from '@/lib/resendClient.server';
 import { wrapEmailLayout, emailDataTable, emailTimestamp, EMAIL_COLORS, SEVERITY_COLORS, METRIC_LABELS } from '@/lib/emailTemplates.server';
@@ -68,6 +68,7 @@ export async function POST(request: NextRequest) {
         const recipients = await getSiteAlertRecipients(siteId, 'thresholdAlerts');
         const tz = await getMachineTimezone(siteId, machineId);
         const baseUrl = request.nextUrl.origin;
+        const siteLabel = await getSiteLabel(siteId);
 
         if (recipients.length > 0) {
           const severityLabel = severity.toUpperCase();
@@ -83,7 +84,7 @@ export async function POST(request: NextRequest) {
                 : undefined;
 
               const html = buildThresholdAlertEmail({
-                siteId,
+                siteLabel,
                 machineId,
                 ruleName,
                 metric,
@@ -160,7 +161,7 @@ export async function POST(request: NextRequest) {
 /* ------------------------------------------------------------------ */
 
 function buildThresholdAlertEmail(params: {
-  siteId: string;
+  siteLabel: string;
   machineId: string;
   ruleName: string;
   metric: string;
@@ -171,7 +172,7 @@ function buildThresholdAlertEmail(params: {
   unsubscribeUrl?: string;
   timezone?: string;
 }): string {
-  const { siteId, machineId, ruleName, metric, value, threshold, operator, severity, unsubscribeUrl, timezone } = params;
+  const { siteLabel, machineId, ruleName, metric, value, threshold, operator, severity, unsubscribeUrl, timezone } = params;
   const color = SEVERITY_COLORS[severity] || SEVERITY_COLORS.warning;
   const metricLabel = METRIC_LABELS[metric] || metric;
 
@@ -179,7 +180,7 @@ function buildThresholdAlertEmail(params: {
     <h2 style="color:${color};margin:0 0 12px;font-size:18px;font-weight:700;text-transform:lowercase;">threshold alert: ${ruleName}</h2>
     <p style="margin:0 0 20px;color:${EMAIL_COLORS.muted};">a metric threshold has been breached on one of your machines.</p>
     ${emailDataTable([
-      { label: 'site', value: siteId },
+      { label: 'site', value: siteLabel },
       { label: 'machine', value: machineId },
       { label: 'rule', value: ruleName },
       { label: 'metric', value: metricLabel },

--- a/web/app/api/cron/display-alerts/route.ts
+++ b/web/app/api/cron/display-alerts/route.ts
@@ -1,6 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { getAdminDb } from '@/lib/firebase-admin';
-import { getSiteAlertRecipients, getMachineTimezone } from '@/lib/adminUtils.server';
+import { getSiteAlertRecipients, getMachineTimezone, getSiteLabel } from '@/lib/adminUtils.server';
 import { getResend, FROM_EMAIL } from '@/lib/resendClient.server';
 import {
   buildDisplayDigestEmail,
@@ -97,6 +97,7 @@ export async function GET(request: NextRequest) {
 
         // Get timezone from the first machine for display
         const tz = await getMachineTimezone(siteId, siteAlerts[0].machineId);
+        const siteLabel = await getSiteLabel(siteId);
 
         // Send per-recipient emails (for individual unsubscribe links)
         for (const recipient of recipients) {
@@ -118,9 +119,9 @@ export async function GET(request: NextRequest) {
             // give the count + site for fast inbox triage.
             const userSubject = userAlerts.length === 1
               ? `[owlette] display event on ${userAlerts[0].machineId}`
-              : `[owlette] ${userAlerts.length} display event(s) in ${siteId}`;
+              : `[owlette] ${userAlerts.length} display event(s) in ${siteLabel}`;
 
-            const html = buildDisplayDigestEmail(siteId, userAlerts, unsubscribeUrl, tz);
+            const html = buildDisplayDigestEmail(siteLabel, userAlerts, unsubscribeUrl, tz);
 
             const result = await resendClient.emails.send({
               from: FROM_EMAIL,

--- a/web/app/api/cron/health-check/route.ts
+++ b/web/app/api/cron/health-check/route.ts
@@ -1,7 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { FieldValue } from 'firebase-admin/firestore';
 import { getAdminDb } from '@/lib/firebase-admin';
-import { getSiteAlertRecipients } from '@/lib/adminUtils.server';
+import { getSiteAlertRecipients, getSiteLabel } from '@/lib/adminUtils.server';
 import { getResend, FROM_EMAIL } from '@/lib/resendClient.server';
 import { wrapEmailLayout, EMAIL_COLORS, emailTimestamp } from '@/lib/emailTemplates.server';
 import { generateUnsubscribeToken } from '@/app/api/unsubscribe/route';
@@ -156,7 +156,7 @@ interface OfflineAlert {
   timezone?: string;
 }
 
-function buildOfflineEmail(siteId: string, alerts: OfflineAlert[], unsubscribeUrl?: string): string {
+function buildOfflineEmail(siteLabel: string, alerts: OfflineAlert[], unsubscribeUrl?: string): string {
   const rows = alerts
     .map(
       (a) => `
@@ -169,7 +169,7 @@ function buildOfflineEmail(siteId: string, alerts: OfflineAlert[], unsubscribeUr
 
   const content = `
     <h2 style="color:${EMAIL_COLORS.red};margin:0 0 12px;font-size:18px;font-weight:700;text-transform:lowercase;">machines offline</h2>
-    <p style="margin:0 0 20px;color:${EMAIL_COLORS.muted};">${alerts.length} machine(s) in site <strong style="color:${EMAIL_COLORS.text};">${siteId}</strong> appear to be offline.</p>
+    <p style="margin:0 0 20px;color:${EMAIL_COLORS.muted};">${alerts.length} machine(s) in site <strong style="color:${EMAIL_COLORS.text};">${siteLabel}</strong> appear to be offline.</p>
     <table width="100%" style="border-collapse:collapse;border:1px solid ${EMAIL_COLORS.border};border-radius:6px;overflow:hidden;" cellpadding="0" cellspacing="0">
       <thead>
         <tr>
@@ -186,7 +186,7 @@ function buildOfflineEmail(siteId: string, alerts: OfflineAlert[], unsubscribeUr
 
   return wrapEmailLayout(content, {
     unsubscribeUrl,
-    preheader: `${alerts.length} machine(s) offline in ${siteId}`,
+    preheader: `${alerts.length} machine(s) offline in ${siteLabel}`,
   });
 }
 
@@ -339,6 +339,8 @@ export async function GET(request: NextRequest) {
         continue;
       }
 
+      const siteLabel = await getSiteLabel(siteId);
+
       // Send individual emails so each user gets their own unsubscribe link
       for (const recipient of recipients) {
         try {
@@ -354,8 +356,8 @@ export async function GET(request: NextRequest) {
             from: FROM_EMAIL,
             to: [recipient.email],
             ...(recipient.ccEmails.length > 0 ? { cc: recipient.ccEmails } : {}),
-            subject: `${userAlerts.length} machine(s) offline in ${siteId}`,
-            html: buildOfflineEmail(siteId, userAlerts, unsubscribeUrl),
+            subject: `${userAlerts.length} machine(s) offline in ${siteLabel}`,
+            html: buildOfflineEmail(siteLabel, userAlerts, unsubscribeUrl),
           });
 
           if (result.error) {

--- a/web/app/api/cron/process-alerts/route.ts
+++ b/web/app/api/cron/process-alerts/route.ts
@@ -1,6 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { getAdminDb } from '@/lib/firebase-admin';
-import { getSiteAlertRecipients, getMachineTimezone } from '@/lib/adminUtils.server';
+import { getSiteAlertRecipients, getMachineTimezone, getSiteLabel } from '@/lib/adminUtils.server';
 import { getResend, FROM_EMAIL } from '@/lib/resendClient.server';
 import { wrapEmailLayout, EMAIL_COLORS, emailTimestamp } from '@/lib/emailTemplates.server';
 import { generateUnsubscribeToken } from '@/app/api/unsubscribe/route';
@@ -39,7 +39,7 @@ interface PendingAlert {
 }
 
 function buildProcessDigestEmail(
-  siteId: string,
+  siteLabel: string,
   alerts: PendingAlert[],
   unsubscribeUrl?: string,
   timezone?: string,
@@ -52,7 +52,7 @@ function buildProcessDigestEmail(
       <h2 style="color:${EMAIL_COLORS.red};margin:0 0 12px;font-size:18px;font-weight:700;text-transform:lowercase;">process ${eventLabel}: ${a.processName}</h2>
       <p style="margin:0 0 20px;color:${EMAIL_COLORS.muted};">a monitored process has ${eventLabel} on one of your machines.</p>
       <table width="100%" style="border-collapse:collapse;" cellpadding="0" cellspacing="0">
-        ${alertRow('site', siteId, false)}
+        ${alertRow('site', siteLabel, false)}
         ${alertRow('machine', a.machineId, true)}
         ${alertRow('process', a.processName, false)}
         ${alertRow('event', eventLabel, true, EMAIL_COLORS.red)}
@@ -87,7 +87,7 @@ function buildProcessDigestEmail(
 
   const content = `
     <h2 style="color:${EMAIL_COLORS.red};margin:0 0 12px;font-size:18px;font-weight:700;text-transform:lowercase;">process alerts: ${alerts.length} event(s)</h2>
-    <p style="margin:0 0 20px;color:${EMAIL_COLORS.muted};">${alerts.length} process event(s) detected in site <strong style="color:${EMAIL_COLORS.text};">${siteId}</strong>.</p>
+    <p style="margin:0 0 20px;color:${EMAIL_COLORS.muted};">${alerts.length} process event(s) detected in site <strong style="color:${EMAIL_COLORS.text};">${siteLabel}</strong>.</p>
     <table width="100%" style="border-collapse:collapse;border:1px solid ${EMAIL_COLORS.border};border-radius:6px;overflow:hidden;" cellpadding="0" cellspacing="0">
       <thead>
         <tr>
@@ -104,7 +104,7 @@ function buildProcessDigestEmail(
   `;
 
   return wrapEmailLayout(content, {
-    preheader: `${alerts.length} process event(s) in ${siteId}`,
+    preheader: `${alerts.length} process event(s) in ${siteLabel}`,
     unsubscribeUrl,
   });
 }
@@ -174,6 +174,7 @@ export async function GET(request: NextRequest) {
 
         // Get timezone from the first machine for display
         const tz = await getMachineTimezone(siteId, siteAlerts[0].machineId);
+        const siteLabel = await getSiteLabel(siteId);
 
         // Send per-recipient emails (for individual unsubscribe links)
         for (const recipient of recipients) {
@@ -189,9 +190,9 @@ export async function GET(request: NextRequest) {
             // Rebuild subject for this user's filtered alerts
             const userSubject = userAlerts.length === 1
               ? `Process ${userAlerts[0].eventType === 'process_start_failed' ? 'failed to start' : 'crashed'}: ${userAlerts[0].processName} on ${userAlerts[0].machineId}`
-              : `${userAlerts.length} process event(s) in ${siteId}`;
+              : `${userAlerts.length} process event(s) in ${siteLabel}`;
 
-            const html = buildProcessDigestEmail(siteId, userAlerts, unsubscribeUrl, tz);
+            const html = buildProcessDigestEmail(siteLabel, userAlerts, unsubscribeUrl, tz);
 
             const result = await resendClient.emails.send({
               from: FROM_EMAIL,

--- a/web/app/settings/alerts/page.tsx
+++ b/web/app/settings/alerts/page.tsx
@@ -1,0 +1,165 @@
+'use client';
+
+/**
+ * /settings/alerts — self-serve alert-email preferences.
+ *
+ * This is the destination for the "manage alerts" link in every alert email
+ * (added in wrapEmailLayout). It lets a recipient toggle individual alert
+ * categories on/off instead of only fully unsubscribing. Each toggle saves
+ * immediately (optimistic, reverting on failure). The same four+1 toggles live
+ * in the account-settings dialog's "alerts" section — this page is the
+ * deep-linkable, focused view of them.
+ */
+
+import { useEffect, useState } from 'react';
+import { useRouter } from 'next/navigation';
+import Link from 'next/link';
+import { useAuth, type UserPreferences } from '@/contexts/AuthContext';
+import { Switch } from '@/components/ui/switch';
+import { Label } from '@/components/ui/label';
+import { OwletteEyeIcon } from '@/components/landing/OwletteEye';
+import { ChevronLeft, Loader2 } from 'lucide-react';
+
+type AlertKey =
+  | 'healthAlerts'
+  | 'processAlerts'
+  | 'thresholdAlerts'
+  | 'cortexAlerts'
+  | 'displayAlerts';
+
+const ALERT_TOGGLES: { key: AlertKey; label: string; desc: string }[] = [
+  {
+    key: 'healthAlerts',
+    label: 'machine offline alerts',
+    desc: 'receive email alerts when machines go offline',
+  },
+  {
+    key: 'processAlerts',
+    label: 'process crash alerts',
+    desc: 'receive email alerts when monitored processes crash or fail to start',
+  },
+  {
+    key: 'thresholdAlerts',
+    label: 'threshold alerts',
+    desc: 'receive email alerts when health metrics (CPU, GPU temp, disk, etc.) exceed configured thresholds',
+  },
+  {
+    key: 'cortexAlerts',
+    label: 'cortex escalation alerts',
+    desc: "receive email alerts when automated diagnostics can't resolve an issue",
+  },
+  {
+    key: 'displayAlerts',
+    label: 'display events',
+    desc: 'receive email alerts when monitors are removed, layouts drift, or display apply fails',
+  },
+];
+
+function pickAlertPrefs(p: UserPreferences): Record<AlertKey, boolean> {
+  return {
+    healthAlerts: p.healthAlerts,
+    processAlerts: p.processAlerts,
+    thresholdAlerts: p.thresholdAlerts,
+    cortexAlerts: p.cortexAlerts,
+    displayAlerts: p.displayAlerts,
+  };
+}
+
+export default function ManageAlertsPage() {
+  const router = useRouter();
+  const { user, userPreferences, updateUserPreferences, loading: authLoading } = useAuth();
+
+  const [prefs, setPrefs] = useState<Record<AlertKey, boolean>>(() =>
+    pickAlertPrefs(userPreferences),
+  );
+  const [savingKey, setSavingKey] = useState<AlertKey | null>(null);
+
+  // Send unauthenticated visitors to login, preserving the return path so they
+  // land back here after signing in (the email link is the common entry point).
+  useEffect(() => {
+    if (!authLoading && !user) {
+      router.replace('/login?redirect=/settings/alerts');
+    }
+  }, [authLoading, user, router]);
+
+  // Keep local toggles in sync with the source-of-truth preferences.
+  // `userPreferences` only changes reference when preferences actually change.
+  useEffect(() => {
+    setPrefs(pickAlertPrefs(userPreferences));
+  }, [userPreferences]);
+
+  if (authLoading || !user) {
+    return (
+      <div className="flex min-h-screen items-center justify-center">
+        <Loader2 className="h-6 w-6 animate-spin text-muted-foreground" />
+      </div>
+    );
+  }
+
+  const toggle = async (key: AlertKey, value: boolean) => {
+    setPrefs((prev) => ({ ...prev, [key]: value })); // optimistic
+    setSavingKey(key);
+    try {
+      await updateUserPreferences({ [key]: value } as Partial<UserPreferences>, {
+        silent: true,
+      });
+    } catch {
+      // updateUserPreferences already surfaces a toast; revert the switch.
+      setPrefs((prev) => ({ ...prev, [key]: !value }));
+    } finally {
+      setSavingKey(null);
+    }
+  };
+
+  return (
+    <div className="min-h-screen bg-background">
+      <div className="mx-auto w-full max-w-2xl px-4 py-10">
+        <Link
+          href="/dashboard"
+          className="mb-6 inline-flex items-center gap-1 text-sm text-muted-foreground hover:text-foreground"
+        >
+          <ChevronLeft className="h-4 w-4" />
+          back to dashboard
+        </Link>
+
+        <div className="mb-6 flex items-center gap-3">
+          <OwletteEyeIcon size={36} />
+          <div>
+            <h1 className="text-xl font-semibold text-foreground">manage alerts</h1>
+            <p className="text-sm text-muted-foreground">
+              choose which email alerts you receive. sent to{' '}
+              <span className="font-medium text-foreground">{user.email}</span>.
+            </p>
+          </div>
+        </div>
+
+        <div className="space-y-3">
+          {ALERT_TOGGLES.map(({ key, label, desc }) => (
+            <div
+              key={key}
+              className="flex items-center justify-between rounded-md border border-border bg-card/50 p-4"
+            >
+              <div className="space-y-0.5 pr-4">
+                <Label htmlFor={key} className="text-foreground">
+                  {label}
+                </Label>
+                <p className="text-xs text-muted-foreground">{desc}</p>
+              </div>
+              <Switch
+                id={key}
+                checked={prefs[key]}
+                onCheckedChange={(v) => toggle(key, v)}
+                disabled={savingKey === key}
+              />
+            </div>
+          ))}
+        </div>
+
+        <p className="mt-6 text-xs text-muted-foreground">
+          changes save automatically. need more control (CC recipients, threshold
+          rules)? open account settings from the dashboard.
+        </p>
+      </div>
+    </div>
+  );
+}

--- a/web/lib/adminUtils.server.ts
+++ b/web/lib/adminUtils.server.ts
@@ -23,6 +23,22 @@ const ADMIN_EMAIL = isProduction
   : process.env.ADMIN_EMAIL_DEV;
 
 /**
+ * Human-readable label for a site, for use in alert emails: `"name (siteId)"`
+ * when the site has a name, otherwise just the id. So recipients see
+ * `TEC (default_site)` instead of the unreadable raw document id. Falls back to
+ * the bare id on any lookup failure.
+ */
+export async function getSiteLabel(siteId: string): Promise<string> {
+  try {
+    const siteDoc = await getAdminDb().collection('sites').doc(siteId).get();
+    const name = (siteDoc.data()?.name as string | undefined)?.trim();
+    return name && name !== siteId ? `${name} (${siteId})` : siteId;
+  } catch {
+    return siteId;
+  }
+}
+
+/**
  * Look up all admin/user email addresses for a given site.
  *
  * Collects emails from:

--- a/web/lib/emailTemplates.server.ts
+++ b/web/lib/emailTemplates.server.ts
@@ -109,11 +109,18 @@ export function wrapEmailLayout(content: string, options: EmailLayoutOptions = {
     ? `<div style="display:none;max-height:0;overflow:hidden;mso-hide:all;">${preheader}</div>`
     : '';
 
+  // "manage alerts" deep-links to the per-category alert preferences so a
+  // recipient can turn off a single alert type instead of unsubscribing from
+  // everything. Shown whenever the unsubscribe link is (i.e. on alert emails).
+  const manageAlertsHtml = unsubscribeUrl
+    ? `<p style="margin:0 0 6px;"><a href="${baseUrl}/settings/alerts" style="color:${EMAIL_COLORS.cyan};text-decoration:underline;font-size:12px;">manage alerts</a></p>`
+    : '';
+
   const unsubscribeHtml = unsubscribeUrl
     ? `<p style="margin:0 0 8px;"><a href="${unsubscribeUrl}" style="color:${EMAIL_COLORS.muted};text-decoration:underline;font-size:12px;">unsubscribe from alerts</a></p>`
     : '';
 
-  return `<!DOCTYPE html><html lang="en"><head><meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1.0"><meta name="color-scheme" content="dark"><meta name="supported-color-schemes" content="dark"><title>owlette</title></head><body style="margin:0;padding:0;background-color:${EMAIL_COLORS.bodyBg};font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,'Helvetica Neue',Arial,sans-serif;-webkit-font-smoothing:antialiased;">${preheaderHtml}<table width="100%" bgcolor="${EMAIL_COLORS.bodyBg}" cellpadding="0" cellspacing="0" role="presentation" style="background-color:${EMAIL_COLORS.bodyBg};"><tr><td align="center" style="padding:32px 16px;"><table width="600" style="max-width:600px;background-color:${EMAIL_COLORS.cardBg};border-radius:8px;border:1px solid ${EMAIL_COLORS.border};" cellpadding="0" cellspacing="0" role="presentation"><tr><td style="padding:28px 32px 20px;text-align:center;border-bottom:1px solid ${EMAIL_COLORS.border};"><a href="https://owlette.app" style="text-decoration:none;"><img src="${logoUrl}" width="48" height="48" alt="owlette" style="display:block;margin:0 auto 12px;border-radius:50%;"></a><table cellpadding="0" cellspacing="0" role="presentation" style="margin:0 auto;"><tr><td><a href="https://owlette.app" style="color:${EMAIL_COLORS.cyan};font-size:20px;font-weight:700;text-transform:lowercase;letter-spacing:0.5px;text-decoration:none;line-height:1;">owlette</a></td>${envBadgeHtml}</tr></table></td></tr><tr><td style="padding:28px 32px;color:${EMAIL_COLORS.text};font-size:14px;line-height:1.7;">${content}</td></tr><tr><td style="padding:20px 32px;border-top:1px solid ${EMAIL_COLORS.border};text-align:center;"><p style="margin:0 0 10px;font-size:12px;"><a href="https://owlette.app" style="color:${EMAIL_COLORS.cyan};text-decoration:none;font-weight:600;">owlette.app</a><span style="color:${EMAIL_COLORS.muted};"> is made by </span><a href="https://tridant.io" style="color:${EMAIL_COLORS.cyan};text-decoration:none;">tridant</a></p><p style="color:${EMAIL_COLORS.muted};font-size:11px;margin:0 0 8px;font-style:italic;">attention is all you need</p>${unsubscribeHtml}<p style="color:${EMAIL_COLORS.border};font-size:11px;margin:0;">this is an automated message from owlette</p></td></tr></table></td></tr></table></body></html>`;
+  return `<!DOCTYPE html><html lang="en"><head><meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1.0"><meta name="color-scheme" content="dark"><meta name="supported-color-schemes" content="dark"><title>owlette</title></head><body style="margin:0;padding:0;background-color:${EMAIL_COLORS.bodyBg};font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,'Helvetica Neue',Arial,sans-serif;-webkit-font-smoothing:antialiased;">${preheaderHtml}<table width="100%" bgcolor="${EMAIL_COLORS.bodyBg}" cellpadding="0" cellspacing="0" role="presentation" style="background-color:${EMAIL_COLORS.bodyBg};"><tr><td align="center" style="padding:32px 16px;"><table width="600" style="max-width:600px;background-color:${EMAIL_COLORS.cardBg};border-radius:8px;border:1px solid ${EMAIL_COLORS.border};" cellpadding="0" cellspacing="0" role="presentation"><tr><td style="padding:28px 32px 20px;text-align:center;border-bottom:1px solid ${EMAIL_COLORS.border};"><a href="https://owlette.app" style="text-decoration:none;"><img src="${logoUrl}" width="48" height="48" alt="owlette" style="display:block;margin:0 auto 12px;border-radius:50%;"></a><table cellpadding="0" cellspacing="0" role="presentation" style="margin:0 auto;"><tr><td><a href="https://owlette.app" style="color:${EMAIL_COLORS.cyan};font-size:20px;font-weight:700;text-transform:lowercase;letter-spacing:0.5px;text-decoration:none;line-height:1;">owlette</a></td>${envBadgeHtml}</tr></table></td></tr><tr><td style="padding:28px 32px;color:${EMAIL_COLORS.text};font-size:14px;line-height:1.7;">${content}</td></tr><tr><td style="padding:20px 32px;border-top:1px solid ${EMAIL_COLORS.border};text-align:center;"><p style="margin:0 0 10px;font-size:12px;"><a href="https://owlette.app" style="color:${EMAIL_COLORS.cyan};text-decoration:none;font-weight:600;">owlette.app</a><span style="color:${EMAIL_COLORS.muted};"> is made by </span><a href="https://tridant.io" style="color:${EMAIL_COLORS.cyan};text-decoration:none;">tridant</a></p><p style="color:${EMAIL_COLORS.muted};font-size:11px;margin:0 0 8px;font-style:italic;">attention is all you need</p>${manageAlertsHtml}${unsubscribeHtml}<p style="color:${EMAIL_COLORS.border};font-size:11px;margin:0;">this is an automated message from owlette</p></td></tr></table></td></tr></table></body></html>`;
 }
 
 /* ------------------------------------------------------------------ */
@@ -307,7 +314,7 @@ function displayAlertRow(label: string, value: string, alt: boolean, highlight?:
  * for `display_monitor_removed` / `display_auto_revert_fired`).
  */
 export function buildDisplayDigestEmail(
-  siteId: string,
+  siteLabel: string,
   alerts: PendingDisplayAlert[],
   unsubscribeUrl?: string,
   timezone?: string,
@@ -327,7 +334,7 @@ export function buildDisplayDigestEmail(
       <h2 style="color:${color};margin:0 0 12px;font-size:18px;font-weight:700;text-transform:lowercase;">${label}</h2>
       <p style="margin:0 0 20px;color:${EMAIL_COLORS.muted};">a display event was detected on one of your machines.</p>
       <table width="100%" style="border-collapse:collapse;border:1px solid ${EMAIL_COLORS.border};border-radius:6px;overflow:hidden;" cellpadding="0" cellspacing="0">
-        ${displayAlertRow('site', siteId, false)}
+        ${displayAlertRow('site', siteLabel, false)}
         ${displayAlertRow('machine', a.machineId, true)}
         ${displayAlertRow('event', label, false, color)}
         ${displayAlertRow('monitor', monitor, true)}
@@ -365,7 +372,7 @@ export function buildDisplayDigestEmail(
 
   const content = `
     <h2 style="color:${EMAIL_COLORS.amber};margin:0 0 12px;font-size:18px;font-weight:700;text-transform:lowercase;">display alerts: ${alerts.length} event(s)</h2>
-    <p style="margin:0 0 20px;color:${EMAIL_COLORS.muted};">${alerts.length} display event(s) detected in site <strong style="color:${EMAIL_COLORS.text};">${siteId}</strong>.</p>
+    <p style="margin:0 0 20px;color:${EMAIL_COLORS.muted};">${alerts.length} display event(s) detected in site <strong style="color:${EMAIL_COLORS.text};">${siteLabel}</strong>.</p>
     <table width="100%" style="border-collapse:collapse;border:1px solid ${EMAIL_COLORS.border};border-radius:6px;overflow:hidden;" cellpadding="0" cellspacing="0">
       <thead>
         <tr>
@@ -382,7 +389,7 @@ export function buildDisplayDigestEmail(
   `;
 
   return wrapEmailLayout(content, {
-    preheader: `${alerts.length} display event(s) in ${siteId}`,
+    preheader: `${alerts.length} display event(s) in ${siteLabel}`,
     unsubscribeUrl,
   });
 }


### PR DESCRIPTION
Two alert-email UX fixes (both from your feedback on the offline + threshold emails).

## 1. Site name instead of the raw id
Alert emails printed `in site default_site` (and the threshold email's `site` row showed `default_site`) — unreadable. New `getSiteLabel(siteId)` helper (web/lib/adminUtils.server.ts) resolves **`name (id)`** — e.g. `TEC (default_site)` — falling back to the bare id if the site has no name. Applied across **all four senders'** bodies, subjects, and preheaders:
- machines-offline (`cron/health-check`)
- threshold (`alerts/trigger`)
- process digest (`cron/process-alerts`)
- display digest (`cron/display-alerts`)

## 2. "manage alerts" link in every alert email
Footers only offered a full unsubscribe. Added a **manage alerts** link (next to unsubscribe) that deep-links to a new **`/settings/alerts`** page where a recipient can toggle individual categories — machine offline, process crash, threshold, cortex escalation, display events — instead of opting out of everything. Rendered by `wrapEmailLayout` whenever an unsubscribe link is present, so **all** alert emails get it with zero per-sender changes. The page reuses the existing `useAuth` preferences (same toggles as the account-settings dialog) and saves each toggle optimistically.

## notes
- **Web-only** — ships with the Railway deploy on merge to dev/main; no Firebase Functions deploy needed.
- Updated the `health-check` test mock for the new `getSiteLabel` dependency; affected suites green, lint + tsc clean.
- `/settings/alerts` is login-gated and fits the existing `/settings/*` pattern (api-keys, webhooks). A token-based no-login variant (reusing the unsubscribe token) is a possible future enhancement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)