### PR TITLE
fix(web): HTML-escape alert-email values + harden alert prefs page

### DIFF
--- a/.claude/hooks/pre-commit-check.mjs
+++ b/.claude/hooks/pre-commit-check.mjs
@@ -43,7 +43,9 @@ try {
 
   // Determine affected areas
   const hasWeb = editedFiles.some(f => /[/\\]web[/\\]/.test(f))
-  const hasAgent = editedFiles.some(f => /[/\\]agent[/\\]/.test(f))
+  // Match the Python agent dir only — NOT web routes that merely live under an
+  // /agent/ path (e.g. web/app/api/agent/*), which are TypeScript, not Python.
+  const hasAgent = editedFiles.some(f => /[/\\]agent[/\\]/.test(f) && !/[/\\]web[/\\]/.test(f))
 
   if (!hasWeb && !hasAgent) {
     process.stdout.write(JSON.stringify({ decision: 'approve' }))

--- a/web/__tests__/lib/emailTemplates.test.ts
+++ b/web/__tests__/lib/emailTemplates.test.ts
@@ -1,0 +1,71 @@
+/** @jest-environment node */
+
+/**
+ * Regression tests for alert-email HTML safety + the "manage alerts" footer.
+ *
+ * Stored-injection guard: alert emails now carry the site NAME (admin-settable
+ * free text) and other operator-controlled values. They must be HTML-escaped
+ * before interpolation so a malicious value can't render phishing markup in
+ * emails sent to co-recipients.
+ */
+
+jest.mock('@sentry/nextjs', () => ({ captureException: jest.fn() }));
+jest.mock('@/lib/resendClient.server', () => ({
+  ENV_LABEL: 'DEVELOPMENT',
+  isProduction: false,
+}));
+
+import {
+  escapeHtml,
+  emailDataTable,
+  wrapEmailLayout,
+  buildDisplayDigestEmail,
+  type PendingDisplayAlert,
+} from '@/lib/emailTemplates.server';
+
+describe('escapeHtml', () => {
+  it('escapes HTML metacharacters', () => {
+    expect(escapeHtml(`<a href="x">&'`)).toBe('&lt;a href=&quot;x&quot;&gt;&amp;&#39;');
+  });
+
+  it('leaves clean text untouched', () => {
+    expect(escapeHtml('TEC (default_site)')).toBe('TEC (default_site)');
+  });
+});
+
+describe('alert-email value escaping (stored-injection regression)', () => {
+  it('emailDataTable escapes dynamic values', () => {
+    const html = emailDataTable([{ label: 'site', value: '<img src=x onerror=alert(1)>' }]);
+    expect(html).not.toContain('<img src=x');
+    expect(html).toContain('&lt;img src=x');
+  });
+
+  it('buildDisplayDigestEmail escapes a malicious site name', () => {
+    const alert: PendingDisplayAlert = {
+      docId: 'd',
+      siteId: 's',
+      machineId: 'm',
+      eventType: 'display_monitor_removed',
+      data: {},
+      agentVersion: '3.0.0',
+      correlatedApplyId: '',
+      timestamp: null,
+    };
+    const html = buildDisplayDigestEmail('<script>evil</script> (s)', [alert], undefined, 'UTC');
+    expect(html).not.toContain('<script>evil');
+    expect(html).toContain('&lt;script&gt;evil');
+  });
+});
+
+describe('wrapEmailLayout — "manage alerts" link', () => {
+  it('renders "manage alerts" + /settings/alerts only when an unsubscribe link is present', () => {
+    const withUnsub = wrapEmailLayout('<p>x</p>', {
+      unsubscribeUrl: 'https://dev.owlette.app/api/unsubscribe?token=t',
+    });
+    expect(withUnsub).toContain('manage alerts');
+    expect(withUnsub).toContain('/settings/alerts');
+
+    const without = wrapEmailLayout('<p>x</p>', {});
+    expect(without).not.toContain('manage alerts');
+  });
+});

--- a/web/__tests__/lib/emailTemplates.test.ts
+++ b/web/__tests__/lib/emailTemplates.test.ts
@@ -17,11 +17,24 @@ jest.mock('@/lib/resendClient.server', () => ({
 
 import {
   escapeHtml,
+  safeEmailSubject,
   emailDataTable,
   wrapEmailLayout,
   buildDisplayDigestEmail,
   type PendingDisplayAlert,
 } from '@/lib/emailTemplates.server';
+
+const displayAlert = (over: Partial<PendingDisplayAlert> = {}): PendingDisplayAlert => ({
+  docId: 'd',
+  siteId: 's',
+  machineId: 'm',
+  eventType: 'display_monitor_removed',
+  data: {},
+  agentVersion: '3.0.0',
+  correlatedApplyId: '',
+  timestamp: null,
+  ...over,
+});
 
 describe('escapeHtml', () => {
   it('escapes HTML metacharacters', () => {
@@ -57,15 +70,47 @@ describe('alert-email value escaping (stored-injection regression)', () => {
   });
 });
 
-describe('wrapEmailLayout — "manage alerts" link', () => {
-  it('renders "manage alerts" + /settings/alerts only when an unsubscribe link is present', () => {
-    const withUnsub = wrapEmailLayout('<p>x</p>', {
+describe('multi-alert display digest escaping', () => {
+  it('escapes machineId in the multi-alert digest table (not just single-alert)', () => {
+    const alerts = [
+      displayAlert({ machineId: '<img src=x onerror=alert(1)>' }),
+      displayAlert({ machineId: 'm2' }),
+    ];
+    const html = buildDisplayDigestEmail('TEC (s)', alerts, undefined, 'UTC');
+    expect(html).not.toContain('<img src=x');
+    expect(html).toContain('&lt;img src=x');
+  });
+});
+
+describe('wrapEmailLayout — manage alerts / unsubscribe footer', () => {
+  it('shows "manage alerts" on EVERY alert email — including the tokenless fallback (unsubscribeUrl undefined)', () => {
+    // The fallback admin recipient has no per-user token, but must still get a
+    // way to turn alerts off. The key being PRESENT (even undefined) marks an
+    // alert email.
+    const fallback = wrapEmailLayout('<p>x</p>', { unsubscribeUrl: undefined });
+    expect(fallback).toContain('manage alerts');
+    expect(fallback).toContain('/settings/alerts');
+    expect(fallback).not.toContain('unsubscribe from alerts'); // no token → no one-click
+
+    const withToken = wrapEmailLayout('<p>x</p>', {
       unsubscribeUrl: 'https://dev.owlette.app/api/unsubscribe?token=t',
     });
-    expect(withUnsub).toContain('manage alerts');
-    expect(withUnsub).toContain('/settings/alerts');
+    expect(withToken).toContain('manage alerts');
+    expect(withToken).toContain('unsubscribe from alerts');
+  });
 
-    const without = wrapEmailLayout('<p>x</p>', {});
-    expect(without).not.toContain('manage alerts');
+  it('does NOT show manage/unsubscribe on transactional emails (no unsubscribeUrl key)', () => {
+    const transactional = wrapEmailLayout('<p>x</p>', { preheader: 'reset your password' });
+    expect(transactional).not.toContain('manage alerts');
+    expect(transactional).not.toContain('unsubscribe from alerts');
+  });
+});
+
+describe('safeEmailSubject', () => {
+  it('strips CR/LF/control chars, collapses whitespace, preserves hyphens', () => {
+    expect(safeEmailSubject('offline in TEC-A4D\r\nBcc: evil@x')).toBe('offline in TEC-A4D Bcc: evil@x');
+  });
+  it('caps length at 200', () => {
+    expect(safeEmailSubject('a'.repeat(500)).length).toBe(200);
   });
 });

--- a/web/app/api/agent/alert/route.ts
+++ b/web/app/api/agent/alert/route.ts
@@ -9,6 +9,7 @@ import {
   emailTimestamp,
   EMAIL_COLORS,
   buildDisplayDigestEmail,
+  safeEmailSubject,
   type PendingDisplayAlert,
 } from '@/lib/emailTemplates.server';
 import { generateUnsubscribeToken } from '@/app/api/unsubscribe/route';
@@ -605,7 +606,7 @@ async function sendCriticalDisplayEmailNow(params: {
         : undefined;
 
       const html = buildDisplayDigestEmail(siteLabel, [alert], unsubscribeUrl, tz);
-      const subject = `[owlette] critical display alert on ${machineId}`;
+      const subject = safeEmailSubject(`[owlette] critical display alert on ${machineId}`);
 
       const result = await resendClient.emails.send({
         from: FROM_EMAIL,

--- a/web/app/api/agent/alert/route.ts
+++ b/web/app/api/agent/alert/route.ts
@@ -1,7 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { FieldValue } from 'firebase-admin/firestore';
 import { getAdminAuth, getAdminDb } from '@/lib/firebase-admin';
-import { getSiteAlertRecipients, getMachineTimezone } from '@/lib/adminUtils.server';
+import { getSiteAlertRecipients, getMachineTimezone, getSiteLabel } from '@/lib/adminUtils.server';
 import { getResend, FROM_EMAIL, ENV_LABEL } from '@/lib/resendClient.server';
 import {
   wrapEmailLayout,
@@ -591,6 +591,7 @@ async function sendCriticalDisplayEmailNow(params: {
     timestamp: new Date(),
   };
 
+  const siteLabel = await getSiteLabel(siteId);
   let emailsSent = 0;
   for (const recipient of recipients) {
     try {
@@ -603,7 +604,7 @@ async function sendCriticalDisplayEmailNow(params: {
         ? `${baseUrl}/api/unsubscribe?token=${generateUnsubscribeToken(recipient.userId)}`
         : undefined;
 
-      const html = buildDisplayDigestEmail(siteId, [alert], unsubscribeUrl, tz);
+      const html = buildDisplayDigestEmail(siteLabel, [alert], unsubscribeUrl, tz);
       const subject = `[owlette] critical display alert on ${machineId}`;
 
       const result = await resendClient.emails.send({

--- a/web/app/api/alerts/trigger/route.ts
+++ b/web/app/api/alerts/trigger/route.ts
@@ -3,7 +3,7 @@ import { getAdminDb } from '@/lib/firebase-admin';
 import { getSiteAlertRecipients, getMachineTimezone, getSiteLabel } from '@/lib/adminUtils.server';
 import { generateUnsubscribeToken } from '@/app/api/unsubscribe/route';
 import { getResend, FROM_EMAIL, ENV_LABEL } from '@/lib/resendClient.server';
-import { wrapEmailLayout, emailDataTable, emailTimestamp, EMAIL_COLORS, SEVERITY_COLORS, METRIC_LABELS } from '@/lib/emailTemplates.server';
+import { wrapEmailLayout, emailDataTable, emailTimestamp, EMAIL_COLORS, SEVERITY_COLORS, METRIC_LABELS, escapeHtml, safeEmailSubject } from '@/lib/emailTemplates.server';
 import { fireWebhooks } from '@/lib/webhookSender.server';
 import { apiError } from '@/lib/apiErrorResponse';
 
@@ -72,7 +72,7 @@ export async function POST(request: NextRequest) {
 
         if (recipients.length > 0) {
           const severityLabel = severity.toUpperCase();
-          const subject = `[${severityLabel}] ${ruleName} — ${machineId}`;
+          const subject = safeEmailSubject(`[${severityLabel}] ${ruleName} — ${machineId}`);
 
           for (const recipient of recipients) {
             // Skip if user has muted this machine
@@ -177,7 +177,7 @@ function buildThresholdAlertEmail(params: {
   const metricLabel = METRIC_LABELS[metric] || metric;
 
   const content = `
-    <h2 style="color:${color};margin:0 0 12px;font-size:18px;font-weight:700;text-transform:lowercase;">threshold alert: ${ruleName}</h2>
+    <h2 style="color:${color};margin:0 0 12px;font-size:18px;font-weight:700;text-transform:lowercase;">threshold alert: ${escapeHtml(ruleName)}</h2>
     <p style="margin:0 0 20px;color:${EMAIL_COLORS.muted};">a metric threshold has been breached on one of your machines.</p>
     ${emailDataTable([
       { label: 'site', value: siteLabel },

--- a/web/app/api/cron/display-alerts/route.ts
+++ b/web/app/api/cron/display-alerts/route.ts
@@ -4,6 +4,7 @@ import { getSiteAlertRecipients, getMachineTimezone, getSiteLabel } from '@/lib/
 import { getResend, FROM_EMAIL } from '@/lib/resendClient.server';
 import {
   buildDisplayDigestEmail,
+  safeEmailSubject,
   type PendingDisplayAlert,
 } from '@/lib/emailTemplates.server';
 import { generateUnsubscribeToken } from '@/app/api/unsubscribe/route';
@@ -127,7 +128,7 @@ export async function GET(request: NextRequest) {
               from: FROM_EMAIL,
               to: [recipient.email],
               ...(recipient.ccEmails.length > 0 ? { cc: recipient.ccEmails } : {}),
-              subject: userSubject,
+              subject: safeEmailSubject(userSubject),
               html,
             });
 

--- a/web/app/api/cron/health-check/route.ts
+++ b/web/app/api/cron/health-check/route.ts
@@ -3,7 +3,7 @@ import { FieldValue } from 'firebase-admin/firestore';
 import { getAdminDb } from '@/lib/firebase-admin';
 import { getSiteAlertRecipients, getSiteLabel } from '@/lib/adminUtils.server';
 import { getResend, FROM_EMAIL } from '@/lib/resendClient.server';
-import { wrapEmailLayout, EMAIL_COLORS, emailTimestamp } from '@/lib/emailTemplates.server';
+import { wrapEmailLayout, EMAIL_COLORS, emailTimestamp, escapeHtml } from '@/lib/emailTemplates.server';
 import { generateUnsubscribeToken } from '@/app/api/unsubscribe/route';
 import { fireWebhooks } from '@/lib/webhookSender.server';
 import { apiError } from '@/lib/apiErrorResponse';
@@ -169,7 +169,7 @@ function buildOfflineEmail(siteLabel: string, alerts: OfflineAlert[], unsubscrib
 
   const content = `
     <h2 style="color:${EMAIL_COLORS.red};margin:0 0 12px;font-size:18px;font-weight:700;text-transform:lowercase;">machines offline</h2>
-    <p style="margin:0 0 20px;color:${EMAIL_COLORS.muted};">${alerts.length} machine(s) in site <strong style="color:${EMAIL_COLORS.text};">${siteLabel}</strong> appear to be offline.</p>
+    <p style="margin:0 0 20px;color:${EMAIL_COLORS.muted};">${alerts.length} machine(s) in site <strong style="color:${EMAIL_COLORS.text};">${escapeHtml(siteLabel)}</strong> appear to be offline.</p>
     <table width="100%" style="border-collapse:collapse;border:1px solid ${EMAIL_COLORS.border};border-radius:6px;overflow:hidden;" cellpadding="0" cellspacing="0">
       <thead>
         <tr>
@@ -186,7 +186,7 @@ function buildOfflineEmail(siteLabel: string, alerts: OfflineAlert[], unsubscrib
 
   return wrapEmailLayout(content, {
     unsubscribeUrl,
-    preheader: `${alerts.length} machine(s) offline in ${siteLabel}`,
+    preheader: `${alerts.length} machine(s) offline in ${escapeHtml(siteLabel)}`,
   });
 }
 

--- a/web/app/api/cron/health-check/route.ts
+++ b/web/app/api/cron/health-check/route.ts
@@ -3,7 +3,7 @@ import { FieldValue } from 'firebase-admin/firestore';
 import { getAdminDb } from '@/lib/firebase-admin';
 import { getSiteAlertRecipients, getSiteLabel } from '@/lib/adminUtils.server';
 import { getResend, FROM_EMAIL } from '@/lib/resendClient.server';
-import { wrapEmailLayout, EMAIL_COLORS, emailTimestamp, escapeHtml } from '@/lib/emailTemplates.server';
+import { wrapEmailLayout, EMAIL_COLORS, emailTimestamp, escapeHtml, safeEmailSubject } from '@/lib/emailTemplates.server';
 import { generateUnsubscribeToken } from '@/app/api/unsubscribe/route';
 import { fireWebhooks } from '@/lib/webhookSender.server';
 import { apiError } from '@/lib/apiErrorResponse';
@@ -161,7 +161,7 @@ function buildOfflineEmail(siteLabel: string, alerts: OfflineAlert[], unsubscrib
     .map(
       (a) => `
       <tr>
-        <td style="padding:10px 14px;color:${EMAIL_COLORS.text};border-bottom:1px solid ${EMAIL_COLORS.border};font-size:13px;">${a.machineId}</td>
+        <td style="padding:10px 14px;color:${EMAIL_COLORS.text};border-bottom:1px solid ${EMAIL_COLORS.border};font-size:13px;">${escapeHtml(a.machineId)}</td>
         <td style="padding:10px 14px;color:${EMAIL_COLORS.muted};border-bottom:1px solid ${EMAIL_COLORS.border};font-size:13px;">${a.heartbeatAgeMinutes} minute(s) ago</td>
       </tr>`
     )
@@ -186,7 +186,7 @@ function buildOfflineEmail(siteLabel: string, alerts: OfflineAlert[], unsubscrib
 
   return wrapEmailLayout(content, {
     unsubscribeUrl,
-    preheader: `${alerts.length} machine(s) offline in ${escapeHtml(siteLabel)}`,
+    preheader: `${alerts.length} machine(s) offline in ${siteLabel}`,
   });
 }
 
@@ -356,7 +356,7 @@ export async function GET(request: NextRequest) {
             from: FROM_EMAIL,
             to: [recipient.email],
             ...(recipient.ccEmails.length > 0 ? { cc: recipient.ccEmails } : {}),
-            subject: `${userAlerts.length} machine(s) offline in ${siteLabel}`,
+            subject: safeEmailSubject(`${userAlerts.length} machine(s) offline in ${siteLabel}`),
             html: buildOfflineEmail(siteLabel, userAlerts, unsubscribeUrl),
           });
 

--- a/web/app/api/cron/process-alerts/route.ts
+++ b/web/app/api/cron/process-alerts/route.ts
@@ -2,7 +2,7 @@ import { NextRequest, NextResponse } from 'next/server';
 import { getAdminDb } from '@/lib/firebase-admin';
 import { getSiteAlertRecipients, getMachineTimezone, getSiteLabel } from '@/lib/adminUtils.server';
 import { getResend, FROM_EMAIL } from '@/lib/resendClient.server';
-import { wrapEmailLayout, EMAIL_COLORS, emailTimestamp, escapeHtml } from '@/lib/emailTemplates.server';
+import { wrapEmailLayout, EMAIL_COLORS, emailTimestamp, escapeHtml, safeEmailSubject } from '@/lib/emailTemplates.server';
 import { generateUnsubscribeToken } from '@/app/api/unsubscribe/route';
 import { apiError } from '@/lib/apiErrorResponse';
 
@@ -49,7 +49,7 @@ function buildProcessDigestEmail(
     const a = alerts[0];
     const eventLabel = a.eventType === 'process_start_failed' ? 'failed to start' : 'crashed';
     const content = `
-      <h2 style="color:${EMAIL_COLORS.red};margin:0 0 12px;font-size:18px;font-weight:700;text-transform:lowercase;">process ${eventLabel}: ${a.processName}</h2>
+      <h2 style="color:${EMAIL_COLORS.red};margin:0 0 12px;font-size:18px;font-weight:700;text-transform:lowercase;">process ${eventLabel}: ${escapeHtml(a.processName)}</h2>
       <p style="margin:0 0 20px;color:${EMAIL_COLORS.muted};">a monitored process has ${eventLabel} on one of your machines.</p>
       <table width="100%" style="border-collapse:collapse;" cellpadding="0" cellspacing="0">
         ${alertRow('site', siteLabel, false)}
@@ -75,10 +75,10 @@ function buildProcessDigestEmail(
       const bg = i % 2 === 1 ? `background:${EMAIL_COLORS.altRow};` : '';
       return `
       <tr>
-        <td style="padding:10px 14px;${bg}color:${EMAIL_COLORS.text};border-bottom:1px solid ${EMAIL_COLORS.border};font-size:13px;">${a.machineId}</td>
-        <td style="padding:10px 14px;${bg}color:${EMAIL_COLORS.text};border-bottom:1px solid ${EMAIL_COLORS.border};font-size:13px;">${a.processName}</td>
+        <td style="padding:10px 14px;${bg}color:${EMAIL_COLORS.text};border-bottom:1px solid ${EMAIL_COLORS.border};font-size:13px;">${escapeHtml(a.machineId)}</td>
+        <td style="padding:10px 14px;${bg}color:${EMAIL_COLORS.text};border-bottom:1px solid ${EMAIL_COLORS.border};font-size:13px;">${escapeHtml(a.processName)}</td>
         <td style="padding:10px 14px;${bg}color:${EMAIL_COLORS.red};border-bottom:1px solid ${EMAIL_COLORS.border};font-size:13px;">${eventLabel}</td>
-        <td style="padding:10px 14px;${bg}color:${EMAIL_COLORS.muted};border-bottom:1px solid ${EMAIL_COLORS.border};font-size:13px;">${a.errorMessage}</td>
+        <td style="padding:10px 14px;${bg}color:${EMAIL_COLORS.muted};border-bottom:1px solid ${EMAIL_COLORS.border};font-size:13px;">${escapeHtml(a.errorMessage)}</td>
       </tr>`;
     })
     .join('');
@@ -104,7 +104,7 @@ function buildProcessDigestEmail(
   `;
 
   return wrapEmailLayout(content, {
-    preheader: `${alerts.length} process event(s) in ${escapeHtml(siteLabel)}`,
+    preheader: `${alerts.length} process event(s) in ${siteLabel}`,
     unsubscribeUrl,
   });
 }
@@ -198,7 +198,7 @@ export async function GET(request: NextRequest) {
               from: FROM_EMAIL,
               to: [recipient.email],
               ...(recipient.ccEmails.length > 0 ? { cc: recipient.ccEmails } : {}),
-              subject: userSubject,
+              subject: safeEmailSubject(userSubject),
               html,
             });
 

--- a/web/app/api/cron/process-alerts/route.ts
+++ b/web/app/api/cron/process-alerts/route.ts
@@ -2,7 +2,7 @@ import { NextRequest, NextResponse } from 'next/server';
 import { getAdminDb } from '@/lib/firebase-admin';
 import { getSiteAlertRecipients, getMachineTimezone, getSiteLabel } from '@/lib/adminUtils.server';
 import { getResend, FROM_EMAIL } from '@/lib/resendClient.server';
-import { wrapEmailLayout, EMAIL_COLORS, emailTimestamp } from '@/lib/emailTemplates.server';
+import { wrapEmailLayout, EMAIL_COLORS, emailTimestamp, escapeHtml } from '@/lib/emailTemplates.server';
 import { generateUnsubscribeToken } from '@/app/api/unsubscribe/route';
 import { apiError } from '@/lib/apiErrorResponse';
 
@@ -87,7 +87,7 @@ function buildProcessDigestEmail(
 
   const content = `
     <h2 style="color:${EMAIL_COLORS.red};margin:0 0 12px;font-size:18px;font-weight:700;text-transform:lowercase;">process alerts: ${alerts.length} event(s)</h2>
-    <p style="margin:0 0 20px;color:${EMAIL_COLORS.muted};">${alerts.length} process event(s) detected in site <strong style="color:${EMAIL_COLORS.text};">${siteLabel}</strong>.</p>
+    <p style="margin:0 0 20px;color:${EMAIL_COLORS.muted};">${alerts.length} process event(s) detected in site <strong style="color:${EMAIL_COLORS.text};">${escapeHtml(siteLabel)}</strong>.</p>
     <table width="100%" style="border-collapse:collapse;border:1px solid ${EMAIL_COLORS.border};border-radius:6px;overflow:hidden;" cellpadding="0" cellspacing="0">
       <thead>
         <tr>
@@ -104,7 +104,7 @@ function buildProcessDigestEmail(
   `;
 
   return wrapEmailLayout(content, {
-    preheader: `${alerts.length} process event(s) in ${siteLabel}`,
+    preheader: `${alerts.length} process event(s) in ${escapeHtml(siteLabel)}`,
     unsubscribeUrl,
   });
 }
@@ -116,7 +116,7 @@ function alertRow(label: string, value: string, alt: boolean, highlight?: string
   return `
     <tr>
       <td style="padding:10px 14px;${bg}color:${EMAIL_COLORS.muted};font-size:13px;font-weight:600;white-space:nowrap;border-bottom:1px solid ${EMAIL_COLORS.border};width:140px;">${label}</td>
-      <td style="padding:10px 14px;${bg}color:${color};font-size:13px;border-bottom:1px solid ${EMAIL_COLORS.border};">${value}</td>
+      <td style="padding:10px 14px;${bg}color:${color};font-size:13px;border-bottom:1px solid ${EMAIL_COLORS.border};">${escapeHtml(value)}</td>
     </tr>`;
 }
 

--- a/web/app/settings/alerts/page.tsx
+++ b/web/app/settings/alerts/page.tsx
@@ -149,7 +149,7 @@ export default function ManageAlertsPage() {
                 id={key}
                 checked={prefs[key]}
                 onCheckedChange={(v) => toggle(key, v)}
-                disabled={savingKey === key}
+                disabled={savingKey !== null}
               />
             </div>
           ))}

--- a/web/lib/cortex-escalation.server.ts
+++ b/web/lib/cortex-escalation.server.ts
@@ -10,7 +10,7 @@
 import { getSiteAlertRecipients, getMachineTimezone } from '@/lib/adminUtils.server';
 import { generateUnsubscribeToken } from '@/app/api/unsubscribe/route';
 import { getResend, FROM_EMAIL, ENV_LABEL, isProduction } from '@/lib/resendClient.server';
-import { wrapEmailLayout, emailDataTable, emailTimestamp, EMAIL_COLORS } from '@/lib/emailTemplates.server';
+import { wrapEmailLayout, emailDataTable, emailTimestamp, EMAIL_COLORS, escapeHtml, safeEmailSubject } from '@/lib/emailTemplates.server';
 
 /**
  * Send an escalation email to site admins when autonomous Cortex cannot resolve an issue.
@@ -36,7 +36,7 @@ export async function escalate(
 
   const tz = await getMachineTimezone(siteId, machineName);
   const baseUrl = process.env.NEXT_PUBLIC_BASE_URL || (isProduction ? 'https://owlette.app' : 'https://dev.owlette.app');
-  const subject = `cortex escalation: ${processName} on ${machineName}`;
+  const subject = safeEmailSubject(`cortex escalation: ${processName} on ${machineName}`);
 
   let anySent = false;
   for (const recipient of recipients) {
@@ -91,7 +91,7 @@ function buildEscalationEmail(
     .replace(/\n/g, '<br>');
 
   const content = `
-    <h2 style="color:${EMAIL_COLORS.amber};margin:0 0 12px;font-size:18px;font-weight:700;text-transform:lowercase;">cortex escalation: ${processName}</h2>
+    <h2 style="color:${EMAIL_COLORS.amber};margin:0 0 12px;font-size:18px;font-weight:700;text-transform:lowercase;">cortex escalation: ${escapeHtml(processName)}</h2>
     <p style="margin:0 0 20px;color:${EMAIL_COLORS.muted};">owlette cortex investigated an issue autonomously but was unable to resolve it. human attention is needed.</p>
 
     ${emailDataTable([

--- a/web/lib/emailTemplates.server.ts
+++ b/web/lib/emailTemplates.server.ts
@@ -51,6 +51,21 @@ export const METRIC_LABELS: Record<string, string> = {
 /*  Data table helper                                                  */
 /* ------------------------------------------------------------------ */
 
+/**
+ * Escape a dynamic value before interpolating it into email HTML. Alert emails
+ * carry operator/admin-controlled free text (site names, machine/process names,
+ * error messages) — escaping prevents stored markup (phishing links, broken
+ * layout) from rendering in emails sent to other recipients.
+ */
+export function escapeHtml(value: string): string {
+  return String(value)
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
+}
+
 interface DataRow {
   label: string;
   value: string;
@@ -67,7 +82,7 @@ export function emailDataTable(rows: DataRow[]): string {
       (r) => {
         const valColor = r.highlight || EMAIL_COLORS.text;
         // Wrap value in a span to override email client auto-link styling
-        const valHtml = `<span style="color:${valColor};${r.highlight ? 'font-weight:700;' : ''}">${r.value}</span>`;
+        const valHtml = `<span style="color:${valColor};${r.highlight ? 'font-weight:700;' : ''}">${escapeHtml(r.value)}</span>`;
         return `<tr><td style="padding:10px 14px;font-weight:600;color:${EMAIL_COLORS.muted};background:${EMAIL_COLORS.altRow};border-bottom:1px solid ${EMAIL_COLORS.border};white-space:nowrap;font-size:13px;">${r.label}</td><td style="padding:10px 14px;color:${valColor};border-bottom:1px solid ${EMAIL_COLORS.border};font-size:13px;">${valHtml}</td></tr>`;
       }
     )
@@ -295,7 +310,7 @@ function displayEventDetail(eventType: string, data: Record<string, unknown>): s
 function displayAlertRow(label: string, value: string, alt: boolean, highlight?: string): string {
   const bg = alt ? `background:${EMAIL_COLORS.altRow};` : '';
   const color = highlight || EMAIL_COLORS.text;
-  const safeValue = value || '—';
+  const safeValue = escapeHtml(value || '—');
   return `
     <tr>
       <td style="padding:10px 14px;${bg}color:${EMAIL_COLORS.muted};font-size:13px;font-weight:600;white-space:nowrap;border-bottom:1px solid ${EMAIL_COLORS.border};width:140px;">${label}</td>
@@ -372,7 +387,7 @@ export function buildDisplayDigestEmail(
 
   const content = `
     <h2 style="color:${EMAIL_COLORS.amber};margin:0 0 12px;font-size:18px;font-weight:700;text-transform:lowercase;">display alerts: ${alerts.length} event(s)</h2>
-    <p style="margin:0 0 20px;color:${EMAIL_COLORS.muted};">${alerts.length} display event(s) detected in site <strong style="color:${EMAIL_COLORS.text};">${siteLabel}</strong>.</p>
+    <p style="margin:0 0 20px;color:${EMAIL_COLORS.muted};">${alerts.length} display event(s) detected in site <strong style="color:${EMAIL_COLORS.text};">${escapeHtml(siteLabel)}</strong>.</p>
     <table width="100%" style="border-collapse:collapse;border:1px solid ${EMAIL_COLORS.border};border-radius:6px;overflow:hidden;" cellpadding="0" cellspacing="0">
       <thead>
         <tr>
@@ -389,7 +404,7 @@ export function buildDisplayDigestEmail(
   `;
 
   return wrapEmailLayout(content, {
-    preheader: `${alerts.length} display event(s) in ${siteLabel}`,
+    preheader: `${alerts.length} display event(s) in ${escapeHtml(siteLabel)}`,
     unsubscribeUrl,
   });
 }

--- a/web/lib/emailTemplates.server.ts
+++ b/web/lib/emailTemplates.server.ts
@@ -66,6 +66,24 @@ export function escapeHtml(value: string): string {
     .replace(/'/g, '&#39;');
 }
 
+/**
+ * Sanitize a value used as an email Subject. Subjects are plain text (Resend
+ * JSON-serializes them), so HTML escaping is wrong here — instead collapse
+ * CR/LF and other control characters (defence against header-injection-shaped
+ * values) and cap the length. Use for any subject that includes dynamic text
+ * (site names, rule/process/machine names).
+ */
+export function safeEmailSubject(value: string): string {
+  // Drop control characters (CR/LF/tab/etc. — header-injection-shaped values)
+  // without HTML-escaping (subjects are plain text), then collapse + cap.
+  let out = '';
+  for (const ch of String(value)) {
+    const code = ch.charCodeAt(0);
+    out += code < 0x20 || code === 0x7f ? ' ' : ch;
+  }
+  return out.replace(/\s+/g, ' ').trim().slice(0, 200);
+}
+
 interface DataRow {
   label: string;
   value: string;
@@ -121,13 +139,19 @@ export function wrapEmailLayout(content: string, options: EmailLayoutOptions = {
     : '';
 
   const preheaderHtml = preheader
-    ? `<div style="display:none;max-height:0;overflow:hidden;mso-hide:all;">${preheader}</div>`
+    ? `<div style="display:none;max-height:0;overflow:hidden;mso-hide:all;">${escapeHtml(preheader)}</div>`
     : '';
 
-  // "manage alerts" deep-links to the per-category alert preferences so a
-  // recipient can turn off a single alert type instead of unsubscribing from
-  // everything. Shown whenever the unsubscribe link is (i.e. on alert emails).
-  const manageAlertsHtml = unsubscribeUrl
+  // Alert emails are signalled by passing the `unsubscribeUrl` option AT ALL —
+  // alert senders always include the key (even when its value is undefined for
+  // the fallback admin recipient, who has no per-user token); transactional
+  // emails (password reset) never pass it. The "manage alerts" deep-link is
+  // shown on EVERY alert email — including ones to the tokenless fallback
+  // recipient — so there is ALWAYS a way to turn alerts off (log in → toggle a
+  // category at /settings/alerts). The one-click token unsubscribe is only
+  // available when we have a per-user token.
+  const isAlertEmail = 'unsubscribeUrl' in options;
+  const manageAlertsHtml = isAlertEmail
     ? `<p style="margin:0 0 6px;"><a href="${baseUrl}/settings/alerts" style="color:${EMAIL_COLORS.cyan};text-decoration:underline;font-size:12px;">manage alerts</a></p>`
     : '';
 
@@ -375,10 +399,10 @@ export function buildDisplayDigestEmail(
       const bg = i % 2 === 1 ? `background:${EMAIL_COLORS.altRow};` : '';
       return `
       <tr>
-        <td style="padding:10px 14px;${bg}color:${EMAIL_COLORS.text};border-bottom:1px solid ${EMAIL_COLORS.border};font-size:13px;">${a.machineId}</td>
+        <td style="padding:10px 14px;${bg}color:${EMAIL_COLORS.text};border-bottom:1px solid ${EMAIL_COLORS.border};font-size:13px;">${escapeHtml(a.machineId)}</td>
         <td style="padding:10px 14px;${bg}color:${color};border-bottom:1px solid ${EMAIL_COLORS.border};font-size:13px;">${label}</td>
-        <td style="padding:10px 14px;${bg}color:${EMAIL_COLORS.text};border-bottom:1px solid ${EMAIL_COLORS.border};font-size:13px;">${monitor}</td>
-        <td style="padding:10px 14px;${bg}color:${EMAIL_COLORS.muted};border-bottom:1px solid ${EMAIL_COLORS.border};font-size:13px;">${detail}</td>
+        <td style="padding:10px 14px;${bg}color:${EMAIL_COLORS.text};border-bottom:1px solid ${EMAIL_COLORS.border};font-size:13px;">${escapeHtml(monitor)}</td>
+        <td style="padding:10px 14px;${bg}color:${EMAIL_COLORS.muted};border-bottom:1px solid ${EMAIL_COLORS.border};font-size:13px;">${escapeHtml(detail)}</td>
       </tr>`;
     })
     .join('');
@@ -404,7 +428,7 @@ export function buildDisplayDigestEmail(
   `;
 
   return wrapEmailLayout(content, {
-    preheader: `${alerts.length} display event(s) in ${escapeHtml(siteLabel)}`,
+    preheader: `${alerts.length} display event(s) in ${siteLabel}`,
     unsubscribeUrl,
   });
 }


### PR DESCRIPTION
Follow-up hardening from the pre-prod cross-model review (Codex caught these; Claude missed them).

- **HTML-escape dynamic email values** — site name (admin free-text) now flows through `escapeHtml` at the row-helper + body/preheader chokepoints (also hardens pre-existing machine/process/error values). Closes the stored-injection vector #27 widened.
- **Alert prefs page** — disable all switches during a save (rapid-toggle race).
- **5th display-email path** — agent critical-path now uses `getSiteLabel` too.
- New `emailTemplates` regression tests (escapeHtml, table escaping, malicious site name, manage-alerts gating). 33 tests green; lint + tsc clean.
- Bonus: fixed a pre-commit-hook misfire (web routes under `/agent/` no longer trigger `pytest`).

Targets `dev`; rolls into the dev→main release (#26).

🤖 Generated with [Claude Code](https://claude.com/claude-code)