### PR TITLE
fix(web): MFA-gate /settings + sanitize agent-error subject

### DIFF
--- a/web/app/api/agent/alert/route.ts
+++ b/web/app/api/agent/alert/route.ts
@@ -422,7 +422,7 @@ export const POST = withRateLimit(
         return NextResponse.json({ success: true, emailSent: false, reason: 'No recipients' });
       }
 
-      const subject = `[ALERT] owlette agent error on ${machineId}`;
+      const subject = safeEmailSubject(`[ALERT] owlette agent error on ${machineId}`);
       const baseUrl = request.nextUrl.origin;
       let emailsSent = 0;
 

--- a/web/proxy.ts
+++ b/web/proxy.ts
@@ -34,6 +34,9 @@ const PROTECTED_PATHS = [
   '/setup',
   '/add',
   '/cortex',
+  // /settings/* (api-keys, webhooks, alerts) manage account + security state and
+  // must require completed MFA like the rest of the app — not just password auth.
+  '/settings',
 ] as const;
 
 // The MFA challenge page itself. Reachable for authenticated users whose


### PR DESCRIPTION
Two pre-prod hardening fixes from the cross-model promotion review (both flagged by Codex):

1. **MFA-gate `/settings`** — add `'/settings'` to `proxy.ts` `PROTECTED_PATHS`. `/settings/*` (api-keys, webhooks, alerts) was reachable by a password-authenticated but MFA-incomplete session. One line; also closes the *pre-existing* api-keys/webhooks exposure, not just the new alerts page.
2. **Sanitize the agent-error email subject** (`agent/alert/route.ts:425`) — the last alert subject still interpolating a raw `machineId`; now wrapped in `safeEmailSubject` like the other five.

lint + tsc clean. Targets `dev`; rolls into the dev→main release (#26).

🤖 Generated with [Claude Code](https://claude.com/claude-code)